### PR TITLE
fix: spec-yml alignments and error location pointers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,16 @@ make verify
 go test ./...
 go build ./...
 ```
+----
+## Commit style 
+- Use clear prefixes:
+  - `feat:` new feature
+  - `fix:` bug fix
+  - `docs:` documentation changes
+  - `test:` tests only
+  - `refactor:` structural changes without behavior change
+- Keep messages brief and to the point.
+----
 ## Final Note
 
 This project is evolving. Expect rules to refine over time. Drive the project forward with clarity and discipline.

--- a/examples/amr_basic.yaml
+++ b/examples/amr_basic.yaml
@@ -3,9 +3,9 @@ name: "amr-basic"
 power:
   battery:
     chemistry: "Li-ion"
-    voltage_v: 14.8
+    voltage_v: 12.8
     max_current_a: 20
-  rail:
+  logic_rail:
     voltage_v: 3.3
     max_current_a: 2
 
@@ -14,7 +14,7 @@ mcu:
   logic_voltage_v: 3.3
   max_gpio_current_ma: 20
 
-driver:
+motor_driver:
   name: "TB6612FNG-like"
   motor_supply_min_v: 2.5
   motor_supply_max_v: 13.5
@@ -29,5 +29,5 @@ motors:
     count: 2
     voltage_min_v: 6
     voltage_max_v: 12
-    stall_current_a: 5.0
-    nominal_current_a: 1.5
+    stall_current_a: 2.5
+    nominal_current_a: 0.9

--- a/examples/amr_parts.yaml
+++ b/examples/amr_parts.yaml
@@ -1,12 +1,13 @@
 spec_version: 0.1
 
-battery:
-  voltage_nominal: 14.8
-  voltage_max: 16.8
-
-logic_rail:
-  voltage: 3.3
-  max_current: 2.0
+power:
+  battery:
+    chemistry: 'Li-ion'
+    voltage_v: 11.1
+    max_current_a: 20.0
+  logic_rail:
+    voltage_v: 3.3
+    max_current_a: 2.0
 
 mcu:
   part: mcus/esp32s3

--- a/internal/output/report.go
+++ b/internal/output/report.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/badimirzai/robotics-verifier-cli/internal/validate"
@@ -15,6 +16,13 @@ func RenderReport(r validate.Report) string {
 		b.WriteString(" ")
 		b.WriteString(f.Code)
 		b.WriteString(": ")
+		if f.Location != nil {
+			b.WriteString(f.Location.File)
+			if f.Location.Line > 0 {
+				b.WriteString(fmt.Sprintf(":%d", f.Location.Line))
+			}
+			b.WriteString(" ")
+		}
 		b.WriteString(f.Message)
 		b.WriteString("\n")
 	}

--- a/internal/parts/store.go
+++ b/internal/parts/store.go
@@ -17,13 +17,13 @@ type DriverPartFile struct {
 	MPN    string `yaml:"mpn"`
 
 	MotorDriver struct {
-		Channels          int     `yaml:"channels"`
-		MotorVoltageMin   float64 `yaml:"motor_voltage_min"`
-		MotorVoltageMax   float64 `yaml:"motor_voltage_max"`
-		LogicVoltageMin   float64 `yaml:"logic_voltage_min"`
-		LogicVoltageMax   float64 `yaml:"logic_voltage_max"`
-		CurrentContinuous float64 `yaml:"current_continuous"`
-		CurrentPeak       float64 `yaml:"current_peak"`
+		Channels         int     `yaml:"channels"`
+		MotorSupplyMinV  float64 `yaml:"motor_supply_min_v"`
+		MotorSupplyMaxV  float64 `yaml:"motor_supply_max_v"`
+		LogicVoltageMinV float64 `yaml:"logic_voltage_min_v"`
+		LogicVoltageMaxV float64 `yaml:"logic_voltage_max_v"`
+		ContinuousPerChA float64 `yaml:"continuous_per_channel_a"`
+		PeakPerChA       float64 `yaml:"peak_per_channel_a"`
 	} `yaml:"motor_driver"`
 }
 
@@ -35,8 +35,8 @@ type MotorPartFile struct {
 	Name   string `yaml:"name"`
 
 	Motor struct {
-		NominalCurrent float64 `yaml:"nominal_current"`
-		StallCurrent   float64 `yaml:"stall_current"`
+		NominalCurrentA float64 `yaml:"nominal_current_a"`
+		StallCurrentA   float64 `yaml:"stall_current_a"`
 	} `yaml:"motor"`
 }
 
@@ -48,7 +48,7 @@ type MCUPartFile struct {
 	Name   string `yaml:"name"`
 
 	MCU struct {
-		LogicVoltage float64 `yaml:"logic_voltage"`
+		LogicVoltageV float64 `yaml:"logic_voltage_v"`
 	} `yaml:"mcu"`
 }
 

--- a/internal/parts/store_test.go
+++ b/internal/parts/store_test.go
@@ -36,13 +36,13 @@ func TestStore_LoadDriver_TB6612FNG(t *testing.T) {
 	if drv.MotorDriver.Channels != 2 {
 		t.Errorf("expected Channels=2, got %d", drv.MotorDriver.Channels)
 	}
-	if drv.MotorDriver.MotorVoltageMin <= 0 || drv.MotorDriver.MotorVoltageMax <= 0 {
+	if drv.MotorDriver.MotorSupplyMinV <= 0 || drv.MotorDriver.MotorSupplyMaxV <= 0 {
 		t.Errorf("expected motor voltage range to be set, got [%.2f, %.2f]",
-			drv.MotorDriver.MotorVoltageMin, drv.MotorDriver.MotorVoltageMax)
+			drv.MotorDriver.MotorSupplyMinV, drv.MotorDriver.MotorSupplyMaxV)
 	}
-	if drv.MotorDriver.CurrentContinuous <= 0 || drv.MotorDriver.CurrentPeak <= 0 {
+	if drv.MotorDriver.ContinuousPerChA <= 0 || drv.MotorDriver.PeakPerChA <= 0 {
 		t.Errorf("expected currents to be >0, got continuous=%.2f, peak=%.2f",
-			drv.MotorDriver.CurrentContinuous, drv.MotorDriver.CurrentPeak)
+			drv.MotorDriver.ContinuousPerChA, drv.MotorDriver.PeakPerChA)
 	}
 }
 
@@ -61,9 +61,9 @@ func TestStore_LoadMotor_Generic12V(t *testing.T) {
 		t.Errorf("expected Name to be set")
 	}
 
-	if m.Motor.NominalCurrent <= 0 || m.Motor.StallCurrent <= 0 {
+	if m.Motor.NominalCurrentA <= 0 || m.Motor.StallCurrentA <= 0 {
 		t.Errorf("expected non-zero currents, got nominal=%.2f, stall=%.2f",
-			m.Motor.NominalCurrent, m.Motor.StallCurrent)
+			m.Motor.NominalCurrentA, m.Motor.StallCurrentA)
 	}
 }
 
@@ -81,8 +81,8 @@ func TestStore_LoadMCU_ESP32S3(t *testing.T) {
 	if mcu.Name == "" {
 		t.Errorf("expected Name to be set")
 	}
-	if mcu.MCU.LogicVoltage <= 0 {
-		t.Errorf("expected non-zero logic voltage, got %.2f", mcu.MCU.LogicVoltage)
+	if mcu.MCU.LogicVoltageV <= 0 {
+		t.Errorf("expected non-zero logic voltage, got %.2f", mcu.MCU.LogicVoltageV)
 	}
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -50,7 +50,7 @@ func resolveMCU(in model.MCU, store *parts.Store) (model.MCU, error) {
 		}
 
 		if out.LogicVoltageV == 0 {
-			out.LogicVoltageV = p.MCU.LogicVoltage
+			out.LogicVoltageV = p.MCU.LogicVoltageV
 		}
 		if out.Name == "" {
 			out.Name = p.Name
@@ -77,22 +77,22 @@ func resolveDriver(in model.MotorDriver, store *parts.Store) (model.MotorDriver,
 			out.Channels = p.MotorDriver.Channels
 		}
 		if out.MotorSupplyMinV == 0 {
-			out.MotorSupplyMinV = p.MotorDriver.MotorVoltageMin
+			out.MotorSupplyMinV = p.MotorDriver.MotorSupplyMinV
 		}
 		if out.MotorSupplyMaxV == 0 {
-			out.MotorSupplyMaxV = p.MotorDriver.MotorVoltageMax
+			out.MotorSupplyMaxV = p.MotorDriver.MotorSupplyMaxV
 		}
 		if out.LogicVoltageMinV == 0 {
-			out.LogicVoltageMinV = p.MotorDriver.LogicVoltageMin
+			out.LogicVoltageMinV = p.MotorDriver.LogicVoltageMinV
 		}
 		if out.LogicVoltageMaxV == 0 {
-			out.LogicVoltageMaxV = p.MotorDriver.LogicVoltageMax
+			out.LogicVoltageMaxV = p.MotorDriver.LogicVoltageMaxV
 		}
 		if out.ContinuousPerChA == 0 {
-			out.ContinuousPerChA = p.MotorDriver.CurrentContinuous
+			out.ContinuousPerChA = p.MotorDriver.ContinuousPerChA
 		}
 		if out.PeakPerChA == 0 {
-			out.PeakPerChA = p.MotorDriver.CurrentPeak
+			out.PeakPerChA = p.MotorDriver.PeakPerChA
 		}
 		if out.Name == "" {
 			out.Name = p.Name
@@ -101,16 +101,16 @@ func resolveDriver(in model.MotorDriver, store *parts.Store) (model.MotorDriver,
 
 	// Sanity checks after merging
 	if out.Channels <= 0 {
-		return model.MotorDriver{}, fmt.Errorf("driver.channels must be > 0 after resolving")
+		return model.MotorDriver{}, fmt.Errorf("motor_driver.channels must be > 0 after resolving")
 	}
 	if out.MotorSupplyMinV == 0 || out.MotorSupplyMaxV == 0 {
-		return model.MotorDriver{}, fmt.Errorf("driver motor supply range missing after resolving")
+		return model.MotorDriver{}, fmt.Errorf("motor_driver.motor_supply_min_v and motor_driver.motor_supply_max_v missing after resolving")
 	}
 	if out.LogicVoltageMinV == 0 || out.LogicVoltageMaxV == 0 {
-		return model.MotorDriver{}, fmt.Errorf("driver logic voltage range missing after resolving")
+		return model.MotorDriver{}, fmt.Errorf("motor_driver.logic_voltage_min_v and motor_driver.logic_voltage_max_v missing after resolving")
 	}
 	if out.PeakPerChA == 0 {
-		return model.MotorDriver{}, fmt.Errorf("driver.peak_per_channel_a missing after resolving")
+		return model.MotorDriver{}, fmt.Errorf("motor_driver.peak_per_channel_a missing after resolving")
 	}
 
 	return out, nil
@@ -126,10 +126,10 @@ func resolveMotor(in model.Motor, store *parts.Store) (model.Motor, error) {
 		}
 
 		if out.NominalCurrentA == 0 {
-			out.NominalCurrentA = p.Motor.NominalCurrent
+			out.NominalCurrentA = p.Motor.NominalCurrentA
 		}
 		if out.StallCurrentA == 0 {
-			out.StallCurrentA = p.Motor.StallCurrent
+			out.StallCurrentA = p.Motor.StallCurrentA
 		}
 		if out.Name == "" {
 			out.Name = p.Name
@@ -137,10 +137,10 @@ func resolveMotor(in model.Motor, store *parts.Store) (model.Motor, error) {
 	}
 
 	if out.Count <= 0 {
-		return model.Motor{}, fmt.Errorf("motor.count must be > 0")
+		return model.Motor{}, fmt.Errorf("motors[].count must be > 0")
 	}
 	if out.StallCurrentA == 0 {
-		return model.Motor{}, fmt.Errorf("motor.stall_current_a missing after resolving")
+		return model.Motor{}, fmt.Errorf("motors[].stall_current_a missing after resolving")
 	}
 
 	return out, nil

--- a/internal/validate/rules.go
+++ b/internal/validate/rules.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/badimirzai/robotics-verifier-cli/internal/model"
 )
@@ -19,10 +20,16 @@ type Finding struct {
 	Severity Severity
 	Code     string
 	Message  string
+	Location *Location
 }
 
 type Report struct {
 	Findings []Finding
+}
+
+type Location struct {
+	File string
+	Line int
 }
 
 func (r Report) HasErrors() bool {
@@ -34,117 +41,180 @@ func (r Report) HasErrors() bool {
 	return false
 }
 
-func RunAll(spec model.RobotSpec) Report {
+func RunAll(spec model.RobotSpec, locs map[string]Location) Report {
 	var r Report
-	r.Findings = append(r.Findings, ruleDriverChannels(spec)...)
-	r.Findings = append(r.Findings, ruleMotorSupplyVoltage(spec)...)
-	r.Findings = append(r.Findings, ruleDriverCurrentHeadroom(spec)...)
-	r.Findings = append(r.Findings, ruleLogicVoltageCompat(spec)...)
-	r.Findings = append(r.Findings, ruleRailCurrentBudget(spec)...)
+	r.Findings = append(r.Findings, ruleDriverChannels(spec, locs)...)
+	r.Findings = append(r.Findings, ruleMotorSupplyVoltage(spec, locs)...)
+	r.Findings = append(r.Findings, ruleDriverCurrentHeadroom(spec, locs)...)
+	r.Findings = append(r.Findings, ruleLogicVoltageCompat(spec, locs)...)
+	r.Findings = append(r.Findings, ruleRailCurrentBudget(spec, locs)...)
 	return r
 }
 
-func ruleDriverChannels(spec model.RobotSpec) []Finding {
+func withLocation(locs map[string]Location, path string, f Finding) Finding {
+	if locs == nil {
+		return f
+	}
+	if loc, ok := findLocation(locs, path); ok {
+		f.Location = &loc
+	}
+	return f
+}
+
+func findLocation(locs map[string]Location, path string) (Location, bool) {
+	if loc, ok := locs[path]; ok {
+		return loc, true
+	}
+	for path != "" {
+		if idx := strings.LastIndex(path, "."); idx >= 0 {
+			path = path[:idx]
+		} else if idx := strings.LastIndex(path, "["); idx >= 0 {
+			path = path[:idx]
+		} else {
+			path = ""
+		}
+		if loc, ok := locs[path]; ok {
+			return loc, true
+		}
+	}
+	return Location{}, false
+}
+
+func ruleDriverChannels(spec model.RobotSpec, locs map[string]Location) []Finding {
 	totalMotors := 0
 	for _, m := range spec.Motors {
 		totalMotors += m.Count
 	}
 	if spec.Driver.Channels <= 0 {
-		return []Finding{{SevError, "DRV_CHANNELS_INVALID", "driver.channels must be > 0"}}
+		return []Finding{withLocation(locs, "motor_driver.channels", Finding{
+			SevError,
+			"DRV_CHANNELS_INVALID",
+			"motor_driver.channels must be > 0",
+			nil,
+		})}
 	}
 	if totalMotors > spec.Driver.Channels {
-		return []Finding{{
+		return []Finding{withLocation(locs, "motor_driver.channels", Finding{
 			SevError,
 			"DRV_CHANNELS_INSUFFICIENT",
-			fmt.Sprintf("motors require %d channels but driver has %d", totalMotors, spec.Driver.Channels),
-		}}
+			fmt.Sprintf("motors require %d channels but motor_driver.channels is %d", totalMotors, spec.Driver.Channels),
+			nil,
+		})}
 	}
-	return []Finding{{
+	return []Finding{withLocation(locs, "motor_driver.channels", Finding{
 		SevInfo,
 		"DRV_CHANNELS_OK",
-		fmt.Sprintf("channels OK: %d motors <= %d driver channels", totalMotors, spec.Driver.Channels),
-	}}
+		fmt.Sprintf("channels OK: %d motors <= %d motor_driver.channels", totalMotors, spec.Driver.Channels),
+		nil,
+	})}
 }
 
-func ruleMotorSupplyVoltage(spec model.RobotSpec) []Finding {
+func ruleMotorSupplyVoltage(spec model.RobotSpec, locs map[string]Location) []Finding {
 	batV := spec.Power.Battery.VoltageV
 	if batV <= 0 {
-		return []Finding{{SevError, "BAT_V_INVALID", "battery.voltage_v must be > 0"}}
+		return []Finding{withLocation(locs, "power.battery.voltage_v", Finding{
+			SevError,
+			"BAT_V_INVALID",
+			"power.battery.voltage_v must be > 0",
+			nil,
+		})}
 	}
 	if batV < spec.Driver.MotorSupplyMinV || batV > spec.Driver.MotorSupplyMaxV {
-		return []Finding{{
+		return []Finding{withLocation(locs, "power.battery.voltage_v", Finding{
 			SevError,
 			"DRV_SUPPLY_RANGE",
-			fmt.Sprintf("battery %.2fV outside driver motor supply range [%.2f, %.2f]V",
+			fmt.Sprintf("battery %.2fV outside motor_driver motor supply range [%.2f, %.2f]V",
 				batV, spec.Driver.MotorSupplyMinV, spec.Driver.MotorSupplyMaxV),
-		}}
+			nil,
+		})}
 	}
 	return nil
 }
 
-func ruleDriverCurrentHeadroom(spec model.RobotSpec) []Finding {
+func ruleDriverCurrentHeadroom(spec model.RobotSpec, locs map[string]Location) []Finding {
 	var out []Finding
-	for _, m := range spec.Motors {
+	for i, m := range spec.Motors {
 		if m.Count <= 0 {
-			out = append(out, Finding{SevError, "MOTOR_COUNT_INVALID", fmt.Sprintf("%s count must be > 0", m.Name)})
+			path := fmt.Sprintf("motors[%d].count", i)
+			out = append(out, withLocation(locs, path, Finding{
+				SevError,
+				"MOTOR_COUNT_INVALID",
+				fmt.Sprintf("motors[%d].count must be > 0", i),
+				nil,
+			}))
 			continue
 		}
 		// Worst-case per channel: stall current. If you want to be conservative, require peak >= stall.
 		if spec.Driver.PeakPerChA < m.StallCurrentA {
-			out = append(out, Finding{
+			out = append(out, withLocation(locs, "motor_driver.peak_per_channel_a", Finding{
 				SevError,
 				"DRV_PEAK_LT_STALL",
-				fmt.Sprintf("driver peak %.2fA < motor %s stall %.2fA (per channel)",
+				fmt.Sprintf("motor_driver.peak_per_channel_a %.2fA < motor %s stall %.2fA (per channel)",
 					spec.Driver.PeakPerChA, m.Name, m.StallCurrentA),
-			})
+				nil,
+			}))
 		}
 		// Continuous should exceed nominal with margin
 		margin := 1.25
 		if spec.Driver.ContinuousPerChA < margin*m.NominalCurrentA {
-			out = append(out, Finding{
+			out = append(out, withLocation(locs, "motor_driver.continuous_per_channel_a", Finding{
 				SevWarn,
 				"DRV_CONT_LOW_MARGIN",
-				fmt.Sprintf("driver continuous %.2fA may be low for motor %s nominal %.2fA (want >= %.2fA)",
+				fmt.Sprintf("motor_driver.continuous_per_channel_a %.2fA may be low for motor %s nominal %.2fA (want >= %.2fA)",
 					spec.Driver.ContinuousPerChA, m.Name, m.NominalCurrentA, margin*m.NominalCurrentA),
-			})
+				nil,
+			}))
 		}
 	}
 	return out
 }
 
-func ruleLogicVoltageCompat(spec model.RobotSpec) []Finding {
+func ruleLogicVoltageCompat(spec model.RobotSpec, locs map[string]Location) []Finding {
 	lv := spec.Power.Rail.VoltageV
 	if lv <= 0 {
-		return []Finding{{SevError, "RAIL_V_INVALID", "power.rail.voltage_v must be > 0"}}
+		return []Finding{withLocation(locs, "power.logic_rail.voltage_v", Finding{
+			SevError,
+			"RAIL_V_INVALID",
+			"power.logic_rail.voltage_v must be > 0",
+			nil,
+		})}
 	}
 	if lv < spec.Driver.LogicVoltageMinV || lv > spec.Driver.LogicVoltageMaxV {
-		return []Finding{{
+		return []Finding{withLocation(locs, "power.logic_rail.voltage_v", Finding{
 			SevError,
 			"LOGIC_V_DRIVER_MISMATCH",
-			fmt.Sprintf("logic rail %.2fV outside driver logic range [%.2f, %.2f]V",
+			fmt.Sprintf("logic rail %.2fV outside motor_driver logic range [%.2f, %.2f]V",
 				lv, spec.Driver.LogicVoltageMinV, spec.Driver.LogicVoltageMaxV),
-		}}
+			nil,
+		})}
 	}
 	if math.Abs(spec.MCU.LogicVoltageV-lv) > 0.25 {
-		return []Finding{{
+		return []Finding{withLocation(locs, "mcu.logic_voltage_v", Finding{
 			SevWarn,
 			"LOGIC_V_MCU_MISMATCH",
 			fmt.Sprintf("MCU logic %.2fV differs from rail %.2fV, check level shifting",
 				spec.MCU.LogicVoltageV, lv),
-		}}
+			nil,
+		})}
 	}
 	return nil
 }
 
-func ruleRailCurrentBudget(spec model.RobotSpec) []Finding {
+func ruleRailCurrentBudget(spec model.RobotSpec, locs map[string]Location) []Finding {
 	railMax := spec.Power.Rail.MaxCurrentA
 	if railMax <= 0 {
-		return []Finding{{SevWarn, "RAIL_I_UNKNOWN", "power.rail.max_current_a not set, cannot budget logic rail current"}}
+		return []Finding{withLocation(locs, "power.logic_rail.max_current_a", Finding{
+			SevWarn,
+			"RAIL_I_UNKNOWN",
+			"power.logic_rail.max_current_a not set, cannot budget logic rail current",
+			nil,
+		})}
 	}
 	// For v1 we do not model currents precisely. We just nudge the user.
-	return []Finding{{
+	return []Finding{withLocation(locs, "power.logic_rail.max_current_a", Finding{
 		SevInfo,
 		"RAIL_BUDGET_NOTE",
 		fmt.Sprintf("logic rail budget set to %.2fA (v1 does not estimate MCU+driver logic draw yet)", railMax),
-	}}
+		nil,
+	})}
 }

--- a/internal/validate/rules_test.go
+++ b/internal/validate/rules_test.go
@@ -98,7 +98,7 @@ func TestRuleDriverChannels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := baseSpec()
 			tt.mutate(&spec)
-			codes := reportCodes(RunAll(spec))
+			codes := reportCodes(RunAll(spec, nil))
 			for _, c := range tt.want {
 				requireHasCode(t, codes, c)
 			}
@@ -143,7 +143,7 @@ func TestRuleMotorSupplyVoltage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := baseSpec()
 			tt.mutate(&spec)
-			codes := reportCodes(RunAll(spec))
+			codes := reportCodes(RunAll(spec, nil))
 			for _, c := range tt.want {
 				requireHasCode(t, codes, c)
 			}
@@ -205,7 +205,7 @@ func TestRuleDriverCurrentHeadroom(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := baseSpec()
 			tt.mutate(&spec)
-			codes := reportCodes(RunAll(spec))
+			codes := reportCodes(RunAll(spec, nil))
 			for _, c := range tt.want {
 				requireHasCode(t, codes, c)
 			}
@@ -258,7 +258,7 @@ func TestRuleLogicVoltageCompat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := baseSpec()
 			tt.mutate(&spec)
-			codes := reportCodes(RunAll(spec))
+			codes := reportCodes(RunAll(spec, nil))
 			for _, c := range tt.want {
 				requireHasCode(t, codes, c)
 			}
@@ -296,7 +296,7 @@ func TestRuleRailCurrentBudget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := baseSpec()
 			tt.mutate(&spec)
-			codes := reportCodes(RunAll(spec))
+			codes := reportCodes(RunAll(spec, nil))
 			for _, c := range tt.want {
 				requireHasCode(t, codes, c)
 			}

--- a/parts/drivers/l298.yaml
+++ b/parts/drivers/l298.yaml
@@ -7,13 +7,13 @@ motor_driver:
   channels: 2
 
   # Motor supply (Vs)
-  motor_voltage_min: 5.0
-  motor_voltage_max: 46.0
+  motor_supply_min_v: 5.0
+  motor_supply_max_v: 46.0
 
   # Logic supply (Vss) -> 5V logic requirement
-  logic_voltage_min: 5.0
-  logic_voltage_max: 7.0
+  logic_voltage_min_v: 5.0
+  logic_voltage_max_v: 7.0
 
   # Conservative thermal limits
-  current_continuous: 1.0
-  current_peak: 2.0
+  continuous_per_channel_a: 1.0
+  peak_per_channel_a: 2.0

--- a/parts/drivers/tb6612fng.yaml
+++ b/parts/drivers/tb6612fng.yaml
@@ -7,13 +7,13 @@ motor_driver:
   channels: 2
 
   # Motor supply (VM)
-  motor_voltage_min: 2.5
-  motor_voltage_max: 13.5
+  motor_supply_min_v: 2.5
+  motor_supply_max_v: 13.5
 
   # Logic supply (VCC)
-  logic_voltage_min: 2.7
-  logic_voltage_max: 5.5
+  logic_voltage_min_v: 2.7
+  logic_voltage_max_v: 5.5
 
   # Output current (per channel)
-  current_continuous: 1.2
-  current_peak: 3.2
+  continuous_per_channel_a: 1.2
+  peak_per_channel_a: 3.2

--- a/parts/mcus/esp32s3.yaml
+++ b/parts/mcus/esp32s3.yaml
@@ -3,4 +3,4 @@ type: mcu
 name: ESP32-S3
 
 mcu:
-  logic_voltage: 3.3
+  logic_voltage_v: 3.3

--- a/parts/motors/generic_dc_12v_gearmotor.yaml
+++ b/parts/motors/generic_dc_12v_gearmotor.yaml
@@ -1,15 +1,13 @@
 part_id: motors/generic_dc_12v_gearmotor
 type: motor
-name: Generic DC gearmotor (12V-class)
+name: Generic DC gearmotor (small 12V-class)
 
 motor:
-  nominal_current: 1.5
-  stall_current: 5.0
-  
-sources:
-  - https://www.pololu.com/product/5204
+  nominal_current_a: 0.9
+  stall_current_a: 2.5
+
 notes:
-  - "Placeholder motor profile for examples. Replace with real motor datasheet when available."
+  - "Placeholder motor profile sized to be safe with TB6612FNG-class drivers."
 confidence:
   nominal_current: low
   stall_current: low


### PR DESCRIPTION
-  Aligned the robot spec YAML keys with spec.go and updated example specs to use power.battery/power.logic_rail so values resolve correctly (amr_parts.yaml, amr_basic.yaml).

- Normalized parts library schemas to spec-compatible field names and updated the loader/resolver to map those new keys (*.yaml, *.yaml, *.yaml, store.go, resolve.go).

- Improved validation output by attaching file/line locations and more precise field paths in messages (validate.go, rules.go, report.go).

- Tuned the example motor/battery values to be physically plausible with the TB6612FNG driver and updated the placeholder motor profile accordingly (amr_parts.yaml, amr_basic.yaml, generic_dc_12v_gearmotor.yaml).

- Updated tests to match the new parts schema and validation entrypoint signature (store_test.go, rules_test.go).