### PR TITLE
Add I2C_ADDR_CONFLICT rule for duplicate I2C addresses on a bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ Battery max discharge uses the following precedence:
 2) power.battery.capacity_ah * power.battery.c_rating
 3) power.battery.max_current_a
 
+I2C bus structure (addresses accept decimal or 0x hex):
+
+```yaml
+i2c_buses:
+  - name: "bus0"
+    devices:
+      - name: "imu_left"
+        address_hex: 0x68
+      - name: "imu_right"
+        address_hex: 104
+```
+
 Unset or missing fields are treated as unknown. Some required values will surface as errors during resolution.
 
 More examples are available in the `examples/` directory.

--- a/examples/i2c-address-conflict.yaml
+++ b/examples/i2c-address-conflict.yaml
@@ -5,3 +5,16 @@ i2c_buses:
         address_hex: 0x68
       - name: "imu_right"
         address_hex: 0x68   # conflict
+        
+mcu:
+  name: "Generic MCU"
+  logic_voltage_v: 3.3
+motor_driver:
+  name: "Generic driver"
+  channels: 1
+  motor_supply_min_v: 6
+  motor_supply_max_v: 12
+  logic_voltage_min_v: 3.0
+  logic_voltage_max_v: 5.5
+  continuous_per_channel_a: 1
+  peak_per_channel_a: 2

--- a/internal/model/spec.go
+++ b/internal/model/spec.go
@@ -1,11 +1,20 @@
 package model
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
 type RobotSpec struct {
-	Name   string      `yaml:"name"`
-	Power  PowerSpec   `yaml:"power"`
-	Motors []Motor     `yaml:"motors"`
-	Driver MotorDriver `yaml:"motor_driver"`
-	MCU    MCU         `yaml:"mcu"`
+	Name     string      `yaml:"name"`
+	Power    PowerSpec   `yaml:"power"`
+	Motors   []Motor     `yaml:"motors"`
+	Driver   MotorDriver `yaml:"motor_driver"`
+	MCU      MCU         `yaml:"mcu"`
+	I2CBuses []I2CBus    `yaml:"i2c_buses"`
 }
 
 type PowerSpec struct {
@@ -56,14 +65,31 @@ type MCU struct {
 	MaxGPIOCurrentmA float64 `yaml:"max_gpio_current_ma"`
 }
 
-type I2CBusses struct {
-	I2cBus []I2CBus
-}
 type I2CBus struct {
-	Name    string
-	Devices []I2CDevice
+	Name    string      `yaml:"name"`
+	Devices []I2CDevice `yaml:"devices"`
 }
+
+type I2CAddress uint16
+
+func (a *I2CAddress) UnmarshalYAML(value *yaml.Node) error {
+	// Allow decimal or 0x-prefixed hex addresses during YAML decoding.
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("i2c address must be a scalar")
+	}
+	raw := strings.TrimSpace(value.Value)
+	if raw == "" {
+		return fmt.Errorf("i2c address is empty")
+	}
+	parsed, err := strconv.ParseUint(raw, 0, 16)
+	if err != nil {
+		return fmt.Errorf("invalid i2c address %q: %w", raw, err)
+	}
+	*a = I2CAddress(parsed)
+	return nil
+}
+
 type I2CDevice struct {
-	Name       string
-	AddressHex uint16
+	Name       string     `yaml:"name"`
+	AddressHex I2CAddress `yaml:"address_hex"`
 }


### PR DESCRIPTION
Introduce a minimal I2C model that lets users declare devices on a bus and detect duplicate I2C addresses. Emit ERROR I2C_ADDR_CONFLICT when multiple devices share the same address on the same bus.