### PR TITLE
feat/add built-in parts library and i2c sensor parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,27 @@ This is a linter. Not a simulator or optimizer.
 
 ---
 
+## Using built-in parts
+
+The repo ships with a small parts library under `parts/`. Reference a part by ID using `part:` and override any fields you need; explicit values in your spec always win.
+
+```yaml
+mcu:
+  part: mcus/esp32-s3-devkitc-1
+
+motor_driver:
+  part: drivers/tb6612fng
+
+motors:
+  - part: motors/tt_6v_dc_gearmotor
+    count: 2
+    stall_current_a: 1.8 # override part default
+```
+
+I2C sensor parts (e.g. `sensors/mpu6050`) include default addresses; you can use them under `i2c_buses.devices` with `part:` or set `address_hex` directly.
+
+---
+
 ## YAML specification
 
 The core fields used in validation are:

--- a/examples/parts-minimal.yaml
+++ b/examples/parts-minimal.yaml
@@ -1,0 +1,21 @@
+spec_version: 0.1
+name: "parts-minimal"
+
+power:
+  battery:
+    chemistry: "Li-ion"
+    voltage_v: 7.4
+    max_current_a: 8.0
+  logic_rail:
+    voltage_v: 3.3
+    max_current_a: 1.0
+
+mcu:
+  part: mcus/esp32-s3-devkitc-1
+
+motor_driver:
+  part: drivers/tb6612fng
+
+motors:
+  - part: motors/tt_6v_dc_gearmotor
+    count: 2

--- a/internal/model/spec.go
+++ b/internal/model/spec.go
@@ -90,6 +90,7 @@ func (a *I2CAddress) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type I2CDevice struct {
+	Part       string     `yaml:"part,omitempty"`
 	Name       string     `yaml:"name"`
 	AddressHex I2CAddress `yaml:"address_hex"`
 }

--- a/internal/parts/store.go
+++ b/internal/parts/store.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/badimirzai/robotics-verifier-cli/internal/model"
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,6 +36,8 @@ type MotorPartFile struct {
 	Name   string `yaml:"name"`
 
 	Motor struct {
+		VoltageMinV     float64 `yaml:"voltage_min_v"`
+		VoltageMaxV     float64 `yaml:"voltage_max_v"`
 		NominalCurrentA float64 `yaml:"nominal_current_a"`
 		StallCurrentA   float64 `yaml:"stall_current_a"`
 	} `yaml:"motor"`
@@ -50,6 +53,19 @@ type MCUPartFile struct {
 	MCU struct {
 		LogicVoltageV float64 `yaml:"logic_voltage_v"`
 	} `yaml:"mcu"`
+}
+
+// I2CSensorPartFile represents the YAML structure for an I2C sensor device.
+// Example: parts/sensors/mpu6050.yaml
+type I2CSensorPartFile struct {
+	PartID string `yaml:"part_id"`
+	Type   string `yaml:"type"`
+	Name   string `yaml:"name"`
+	MPN    string `yaml:"mpn"`
+
+	I2CDevice struct {
+		AddressHex model.I2CAddress `yaml:"address_hex"`
+	} `yaml:"i2c_device"`
 }
 
 // Store knows how to load part files from a base directory (usually "./parts").
@@ -92,6 +108,18 @@ func (s *Store) LoadMCU(partID string) (MCUPartFile, error) {
 	}
 	if part.Type != "mcu" {
 		return MCUPartFile{}, fmt.Errorf("expected type mcu, got %q", part.Type)
+	}
+	return part, nil
+}
+
+// LoadI2CSensor loads an I2C sensor part by ID, e.g. "sensors/mpu6050".
+func (s *Store) LoadI2CSensor(partID string) (I2CSensorPartFile, error) {
+	var part I2CSensorPartFile
+	if err := s.loadPart(partID, &part); err != nil {
+		return I2CSensorPartFile{}, err
+	}
+	if part.Type != "i2c_sensor" {
+		return I2CSensorPartFile{}, fmt.Errorf("expected type i2c_sensor, got %q", part.Type)
 	}
 	return part, nil
 }

--- a/internal/parts/store_test.go
+++ b/internal/parts/store_test.go
@@ -93,3 +93,22 @@ func TestStore_LoadMissingPart_ReturnsError(t *testing.T) {
 		t.Fatalf("expected error when loading missing driver, got nil")
 	}
 }
+
+func TestStore_LoadI2CSensor_MPU6050(t *testing.T) {
+	store := NewStore(testPartsDir(t))
+
+	sensor, err := store.LoadI2CSensor("sensors/mpu6050")
+	if err != nil {
+		t.Fatalf("LoadI2CSensor(mpu6050) returned error: %v", err)
+	}
+
+	if sensor.Type != "i2c_sensor" {
+		t.Errorf("expected Type=i2c_sensor, got %q", sensor.Type)
+	}
+	if sensor.Name == "" {
+		t.Errorf("expected Name to be set")
+	}
+	if sensor.I2CDevice.AddressHex == 0 {
+		t.Errorf("expected non-zero address, got 0")
+	}
+}

--- a/parts/drivers/l298.yaml
+++ b/parts/drivers/l298.yaml
@@ -6,14 +6,14 @@ mpn: L298
 motor_driver:
   channels: 2
 
-  # Motor supply (Vs)
+  # Motor supply (Vs) from ST L298 datasheet.
   motor_supply_min_v: 5.0
   motor_supply_max_v: 46.0
 
-  # Logic supply (Vss) -> 5V logic requirement
+  # Logic supply (Vss) 5V-class logic window.
   logic_voltage_min_v: 5.0
   logic_voltage_max_v: 7.0
 
-  # Conservative thermal limits
+  # Conservative thermal limits for continuous vs peak.
   continuous_per_channel_a: 1.0
   peak_per_channel_a: 2.0

--- a/parts/drivers/l298n.yaml
+++ b/parts/drivers/l298n.yaml
@@ -1,0 +1,19 @@
+part_id: drivers/l298n
+type: motor_driver
+name: L298N Dual H-Bridge (module)
+mpn: L298N
+
+motor_driver:
+  channels: 2
+
+  # Motor supply (Vs) from ST L298 datasheet (module uses same IC).
+  motor_supply_min_v: 5.0
+  motor_supply_max_v: 46.0
+
+  # Logic supply (Vss) 5V logic window; module typically expects 5V logic.
+  logic_voltage_min_v: 4.5
+  logic_voltage_max_v: 7.0
+
+  # Typical module ratings with basic heatsinking.
+  continuous_per_channel_a: 1.0
+  peak_per_channel_a: 2.0

--- a/parts/drivers/tb6612fng.yaml
+++ b/parts/drivers/tb6612fng.yaml
@@ -6,14 +6,14 @@ mpn: TB6612FNG
 motor_driver:
   channels: 2
 
-  # Motor supply (VM)
+  # Motor supply (VM) from Toshiba TB6612FNG datasheet.
   motor_supply_min_v: 2.5
   motor_supply_max_v: 13.5
 
-  # Logic supply (VCC)
+  # Logic supply (VCC) from datasheet.
   logic_voltage_min_v: 2.7
   logic_voltage_max_v: 5.5
 
-  # Output current (per channel)
+  # Output current (per channel), typical continuous/peak ratings.
   continuous_per_channel_a: 1.2
   peak_per_channel_a: 3.2

--- a/parts/mcus/arduino-uno-r3.yaml
+++ b/parts/mcus/arduino-uno-r3.yaml
@@ -1,0 +1,7 @@
+part_id: mcus/arduino-uno-r3
+type: mcu
+name: Arduino Uno R3
+
+mcu:
+  # ATmega328P logic on Uno R3 is 5V (Arduino documentation).
+  logic_voltage_v: 5.0

--- a/parts/mcus/esp32-s3-devkitc-1.yaml
+++ b/parts/mcus/esp32-s3-devkitc-1.yaml
@@ -1,0 +1,7 @@
+part_id: mcus/esp32-s3-devkitc-1
+type: mcu
+name: ESP32-S3-DevKitC-1
+
+mcu:
+  # Board uses ESP32-S3 3.3V logic domain (Espressif docs).
+  logic_voltage_v: 3.3

--- a/parts/mcus/esp32s3.yaml
+++ b/parts/mcus/esp32s3.yaml
@@ -3,4 +3,5 @@ type: mcu
 name: ESP32-S3
 
 mcu:
+  # ESP32-S3 logic domain is 3.3V (Espressif datasheet).
   logic_voltage_v: 3.3

--- a/parts/motors/generic_dc_12v_gearmotor.yaml
+++ b/parts/motors/generic_dc_12v_gearmotor.yaml
@@ -3,6 +3,9 @@ type: motor
 name: Generic DC gearmotor (small 12V-class)
 
 motor:
+  # Typical 12V-class gearmotor listings (generic vendor data).
+  voltage_min_v: 9.0
+  voltage_max_v: 12.0
   nominal_current_a: 0.9
   stall_current_a: 2.5
 

--- a/parts/motors/n20_12v_micro_gearmotor.yaml
+++ b/parts/motors/n20_12v_micro_gearmotor.yaml
@@ -1,0 +1,10 @@
+part_id: motors/n20_12v_micro_gearmotor
+type: motor
+name: N20 micro gearmotor (12V)
+
+motor:
+  # Representative N20 12V micro gearmotor specs from common vendor listings.
+  voltage_min_v: 9.0
+  voltage_max_v: 12.0
+  nominal_current_a: 0.15
+  stall_current_a: 1.2

--- a/parts/motors/n20_6v_micro_gearmotor.yaml
+++ b/parts/motors/n20_6v_micro_gearmotor.yaml
@@ -1,0 +1,10 @@
+part_id: motors/n20_6v_micro_gearmotor
+type: motor
+name: N20 micro gearmotor (6V)
+
+motor:
+  # Representative N20 6V micro gearmotor specs from common vendor listings.
+  voltage_min_v: 3.0
+  voltage_max_v: 6.0
+  nominal_current_a: 0.12
+  stall_current_a: 0.8

--- a/parts/motors/tt_6v_dc_gearmotor.yaml
+++ b/parts/motors/tt_6v_dc_gearmotor.yaml
@@ -1,0 +1,10 @@
+part_id: motors/tt_6v_dc_gearmotor
+type: motor
+name: TT 6V DC gearmotor
+
+motor:
+  # Typical TT motor listings at 6V (common kit motors).
+  voltage_min_v: 3.0
+  voltage_max_v: 6.0
+  nominal_current_a: 0.2
+  stall_current_a: 1.5

--- a/parts/sensors/bme280.yaml
+++ b/parts/sensors/bme280.yaml
@@ -1,0 +1,8 @@
+part_id: sensors/bme280
+type: i2c_sensor
+name: BME280 Environmental Sensor
+mpn: BME280
+
+i2c_device:
+  # Default address 0x76 (datasheet), alternate 0x77 via SDO pin.
+  address_hex: 0x76

--- a/parts/sensors/mpu6050.yaml
+++ b/parts/sensors/mpu6050.yaml
@@ -1,0 +1,8 @@
+part_id: sensors/mpu6050
+type: i2c_sensor
+name: MPU-6050 IMU
+mpn: MPU-6050
+
+i2c_device:
+  # Default address when AD0 is low (datasheet). Alt 0x69 when AD0 high.
+  address_hex: 0x68

--- a/parts/sensors/vl53l0x.yaml
+++ b/parts/sensors/vl53l0x.yaml
@@ -1,0 +1,8 @@
+part_id: sensors/vl53l0x
+type: i2c_sensor
+name: VL53L0X Time-of-Flight Sensor
+mpn: VL53L0X
+
+i2c_device:
+  # Default I2C address per ST datasheet.
+  address_hex: 0x29


### PR DESCRIPTION
Introduce a small built-in parts library (drivers, MCUs, motors, I2C sensors) with stable IDs and documented defaults.
Extend part resolution to support motor voltage ranges and I2C devices via part:.
Add a minimal example and README guidance for using built-in parts.