### PR TITLE
feat/ Support project-local rv_parts directory for part resolution

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -52,3 +52,16 @@ rv check robot.yaml
 rv init --template 4wd-clean --out robot.yaml --force
 rv check robot.yaml
 ```
+
+## Parts libraries
+
+```bash
+# Use project-local parts in ./rv_parts (automatic)
+rv check robot.yaml
+
+# Add extra search directories (repeatable)
+rv check robot.yaml --parts-dir ./vendor/parts --parts-dir /opt/robot-parts
+
+# Use environment variable paths (split by OS list separator)
+RV_PARTS_DIRS="./vendor/parts:/opt/robot-parts" rv check robot.yaml
+```

--- a/README.md
+++ b/README.md
@@ -245,6 +245,33 @@ I2C sensor parts (e.g. `sensors/mpu6050`) include default addresses; you can use
 
 ---
 
+## Project-local parts
+
+If you have project-specific parts, put them in `./rv_parts/` relative to where you run `rv`. Example layout:
+
+```
+rv_parts/
+  motors/
+    custom_gear_motor.yaml
+  drivers/
+    custom_driver.yaml
+```
+
+Reference them by ID in your spec:
+
+```yaml
+motor_driver:
+  part: drivers/custom_driver
+
+motors:
+  - part: motors/custom_gear_motor
+    count: 2
+```
+
+The resolver searches directories in this order (earlier wins): `./rv_parts`, built-in `parts/`, `--parts-dir` (repeatable), and `RV_PARTS_DIRS` (split by your OS path list separator, `:` on Unix, `;` on Windows).
+
+---
+
 ## YAML specification
 
 The core fields used in validation are:

--- a/cmd/parts_paths.go
+++ b/cmd/parts_paths.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/badimirzai/robotics-verifier-cli/internal/parts"
+)
+
+func buildPartsStore(cliDirs []string, envVar string) (*parts.Store, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	searchDirs := partsSearchDirs(cwd, cliDirs, envVar)
+	return parts.NewStoreWithDirs(searchDirs), nil
+}
+
+func partsSearchDirs(cwd string, cliDirs []string, envVar string) []string {
+	dirs := []string{
+		filepath.Join(cwd, "rv_parts"),
+		filepath.Join(cwd, "parts"),
+	}
+
+	for _, dir := range cliDirs {
+		if dir == "" {
+			continue
+		}
+		dirs = append(dirs, filepath.Clean(dir))
+	}
+
+	dirs = append(dirs, parsePartsEnvDirs(envVar)...)
+	return dirs
+}
+
+func parsePartsEnvDirs(envVar string) []string {
+	if envVar == "" {
+		return nil
+	}
+	rawDirs := strings.Split(envVar, string(filepath.ListSeparator))
+	dirs := make([]string, 0, len(rawDirs))
+	for _, dir := range rawDirs {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		dirs = append(dirs, filepath.Clean(dir))
+	}
+	return dirs
+}

--- a/cmd/parts_paths_test.go
+++ b/cmd/parts_paths_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildPartsStore_UsesCLIDirs(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "project")
+	partsDir := filepath.Join(tmp, "custom_parts")
+	if err := os.MkdirAll(filepath.Join(partsDir, "motors"), 0o755); err != nil {
+		t.Fatalf("mkdir custom parts: %v", err)
+	}
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+
+	partYAML := `part_id: motors/custom_motor
+type: motor
+name: CLI Motor
+motor:
+  voltage_min_v: 6
+  voltage_max_v: 12
+  nominal_current_a: 0.4
+  stall_current_a: 1.0
+`
+	if err := os.WriteFile(filepath.Join(partsDir, "motors", "custom_motor.yaml"), []byte(partYAML), 0o644); err != nil {
+		t.Fatalf("write custom part: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	store, err := buildPartsStore([]string{partsDir}, "")
+	if err != nil {
+		t.Fatalf("buildPartsStore: %v", err)
+	}
+	part, err := store.LoadMotor("motors/custom_motor")
+	if err != nil {
+		t.Fatalf("LoadMotor: %v", err)
+	}
+	if part.Name != "CLI Motor" {
+		t.Fatalf("expected CLI part to load, got %q", part.Name)
+	}
+}
+
+func TestPartsSearchDirs_Order(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "project")
+	cliDir := filepath.Join(tmp, "cli_parts")
+	envDir := filepath.Join(tmp, "env_parts")
+
+	got := partsSearchDirs(cwd, []string{cliDir}, envDir)
+	if len(got) < 4 {
+		t.Fatalf("expected at least 4 search dirs, got %d", len(got))
+	}
+	if got[0] != filepath.Join(cwd, "rv_parts") {
+		t.Fatalf("expected rv_parts first, got %q", got[0])
+	}
+	if got[1] != filepath.Join(cwd, "parts") {
+		t.Fatalf("expected built-in parts second, got %q", got[1])
+	}
+	if got[2] != filepath.Clean(cliDir) {
+		t.Fatalf("expected cli dir third, got %q", got[2])
+	}
+	if got[3] != filepath.Clean(envDir) {
+		t.Fatalf("expected env dir fourth, got %q", got[3])
+	}
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/badimirzai/robotics-verifier-cli/internal/model"
 	"github.com/badimirzai/robotics-verifier-cli/internal/output"
-	"github.com/badimirzai/robotics-verifier-cli/internal/parts"
 	"github.com/badimirzai/robotics-verifier-cli/internal/resolve"
 	"github.com/badimirzai/robotics-verifier-cli/internal/validate"
 	"github.com/spf13/cobra"
@@ -91,7 +90,11 @@ Examples:
 			return handleCheckError(outputFormat, 3, path, fmt.Errorf("decode yaml: %w", err), nil, prettyOutput, outFile)
 		}
 
-		store := parts.NewStore("parts")
+		partsDirs, _ := cmd.Flags().GetStringArray("parts-dir")
+		store, err := buildPartsStore(partsDirs, os.Getenv("RV_PARTS_DIRS"))
+		if err != nil {
+			return handleCheckError(outputFormat, 3, path, fmt.Errorf("build parts search paths: %w", err), nil, prettyOutput, outFile)
+		}
 		resolved, err := resolve.ResolveAll(raw, store)
 		if err != nil {
 			return handleCheckError(outputFormat, 3, path, fmt.Errorf("resolve spec with parts: %w", err), nil, prettyOutput, outFile)
@@ -125,6 +128,7 @@ func init() {
 	checkCmd.Flags().StringP("output", "o", "text", "Output format: text or json")
 	checkCmd.Flags().Bool("pretty", false, "Pretty print JSON to stdout (requires --output json)")
 	checkCmd.Flags().String("out-file", "", "Write compact JSON to file (requires --output json)")
+	checkCmd.Flags().StringArray("parts-dir", nil, "Additional parts directory (repeatable; after rv_parts and built-in parts)")
 	rootCmd.AddCommand(checkCmd)
 }
 


### PR DESCRIPTION
Allow users to add a rv_parts/directory in their project repo and have rv check automatically resolve part: references from there (with clear precedence). 