### PR TITLE
Feat/ Add measurable rail inference coverage and provenance

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -14,9 +14,13 @@ rv check <file.yaml> --output json --pretty --out-file report.json
 rv scan <path>                         Import KiCad BOM CSV, KiCad .net, or project directory
 rv scan <bom.csv> --map mapping.yaml   Use explicit header mapping YAML
 rv scan <bom.csv> --out report.json    Write scan report to a specific path
+rv scan <netlist.net> --meta .architon/meta.yaml
+                                      Enable metadata-backed voltage rules
+rv scan <netlist.net> --rails          Show rail inference details (--explain-rails)
 rv scan .                              Auto-detect BOM and/or netlist in current directory
 rv scan . --bom bom/bom.csv --netlist exports/project.net
                                       Override detected project files
+rv init                                Create .architon/meta.yaml and README.md
 rv init --list                        List available templates
 rv init --template <name>             Write a template to robot.yaml
 rv init --template <name> --out path  Write a template to a specific path
@@ -31,8 +35,11 @@ rv scan --help                         Show scan command options
 
 ```text
 --output json             print machine readable JSON to stdout
+--style report|classic    force human-readable style
+--warn-as-error           return exit code 2 for warning-only results
 --pretty                  pretty print JSON to stdout (requires --output json)
 --out-file <path>         write compact JSON to file (requires --output json)
+--parts-dir <dir>         add parts directory (repeatable)
 --no-color                disable colored output
 --debug                   enable debug mode (or use RV_DEBUG=1)
 ```
@@ -43,16 +50,19 @@ rv scan --help                         Show scan command options
 --map <file.yaml>         explicit BOM header mapping file
 --bom <file>              override BOM file path for project directory scans
 --netlist <file>          override netlist file path for project directory scans
+--meta <file.yaml>        metadata for sources, regulators, and component limits
+--explain-rails           print rail voltage inference and confidence details
+--rails                   alias for --explain-rails
 --out <report.json>       write scan report to a specific path
 ```
 
-## Exit codes (`rv scan`)
+## Exit codes (`rv check` and `rv scan`)
 
 ```text
-0  success
-1  rule violations
-2  parse errors
-3  tool failure / internal error
+0  clean / informational only
+1  warnings detected, no violations
+2  rule violations
+3  tool execution failure, including scan parse errors
 ```
 
 ## Examples
@@ -70,6 +80,8 @@ rv scan .
 rv scan . --bom bom/bom.csv --netlist exports/project.net
 rv scan bom.csv --map examples/mapping.yaml
 rv scan bom.csv --out my-report.json
+rv scan exports/project.net --meta .architon/meta.yaml --rails
+rv init
 rv init --template 4wd-problem
 rv check robot.yaml
 rv init --template 4wd-clean --out robot.yaml --force
@@ -78,11 +90,13 @@ rv check robot.yaml
 
 ## Scan report summary
 
-`rv scan` report `summary` includes:
+`rv scan` report includes:
 
-- `delimiter` for KiCad BOM imports: `,`, `;`, or `\t`
-- `nets` when KiCad netlist data is present
-- `next_steps` only when `parse_errors_count > 0`
+- `summary.delimiter` for KiCad BOM imports: `,`, `;`, or `\t`
+- `summary.nets` when KiCad netlist data is present
+- `summary.next_steps` only when `parse_errors_count > 0`
+- `derived.rail_inferences` and `derived.rail_coverage` for netlist-backed voltage inference
+- `rules[].inference` provenance for voltage-based findings when available
 
 Directory scan detection order:
 
@@ -92,8 +106,10 @@ Directory scan detection order:
 Successful `rv scan` terminal output includes:
 
 - `ARCHITON SCAN`
-- `Target`, `Parts`, `Nets`, `Errors`, `Warnings`
+- `Target`, `Result`, `Parts`, `Nets`, `Errors`, `Warnings`, `Rules`, `Violations`
+- compact rail coverage: `Inferred voltages: N Unknown voltage nets: N Rail coverage: LEVEL PCT%`
 - `Detected BOM` and `Detected Netlist` when directory scan auto-detects files
+- rail inference table when `--explain-rails` or `--rails` is passed
 
 Example success snippet:
 

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -16,7 +16,7 @@ rv scan <bom.csv> --map mapping.yaml   Use explicit header mapping YAML
 rv scan <bom.csv> --out report.json    Write scan report to a specific path
 rv scan <netlist.net> --meta .architon/meta.yaml
                                       Enable metadata-backed voltage rules
-rv scan <netlist.net> --rails          Show rail inference details (--explain-rails)
+rv scan <netlist.net> --rails          Show rail inference details
 rv scan .                              Auto-detect BOM and/or netlist in current directory
 rv scan . --bom bom/bom.csv --netlist exports/project.net
                                       Override detected project files
@@ -36,7 +36,7 @@ rv scan --help                         Show scan command options
 ```text
 --output json             print machine readable JSON to stdout
 --style report|classic    force human-readable style
---warn-as-error           return exit code 2 for warning-only results
+--warn-as-error           treat warning-only results as violations
 --pretty                  pretty print JSON to stdout (requires --output json)
 --out-file <path>         write compact JSON to file (requires --output json)
 --parts-dir <dir>         add parts directory (repeatable)
@@ -51,19 +51,12 @@ rv scan --help                         Show scan command options
 --bom <file>              override BOM file path for project directory scans
 --netlist <file>          override netlist file path for project directory scans
 --meta <file.yaml>        metadata for sources, regulators, and component limits
---explain-rails           print rail voltage inference and confidence details
---rails                   alias for --explain-rails
+--rails                   print rail voltage inference and confidence details
+--explain-rails           legacy alias for --rails
 --out <report.json>       write scan report to a specific path
 ```
 
-## Exit codes (`rv check` and `rv scan`)
-
-```text
-0  clean / informational only
-1  warnings detected, no violations
-2  rule violations
-3  tool execution failure, including scan parse errors
-```
+Exit behavior is documented in `README.md`.
 
 ## Examples
 
@@ -109,7 +102,7 @@ Successful `rv scan` terminal output includes:
 - `Target`, `Result`, `Parts`, `Nets`, `Errors`, `Warnings`, `Rules`, `Violations`
 - compact rail coverage: `Inferred voltages: N Unknown voltage nets: N Rail coverage: LEVEL PCT%`
 - `Detected BOM` and `Detected Netlist` when directory scan auto-detects files
-- rail inference table when `--explain-rails` or `--rails` is passed
+- rail inference table when `--rails` is passed; `--explain-rails` remains supported as a legacy alias
 
 Example success snippet:
 

--- a/README.md
+++ b/README.md
@@ -94,14 +94,17 @@ Expected output example:
 ```bash
 ARCHITON SCAN
 Target: .
+Result: OK — no scan violations detected
 Parts: 7
 Nets: 59
 Errors: 0
 Warnings: 0
 Rules: 0
 Violations: 0
+Inferred voltages: <n> Unknown voltage nets: <n> Rail coverage: <LEVEL> <PCT>%
 Detected Netlist: <path>
 Wrote architon-report.json
+exit code: 0
 ```
 Architon automatically detects KiCad .net netlists and BOM CSV files
 and produces a deterministic DesignIR report.
@@ -130,13 +133,16 @@ rv check robot.yaml
 rv scan examples/bom/bom.csv
 # ARCHITON SCAN
 # Target: examples/bom/bom.csv
+# Result: OK — no scan violations detected
 # Parts: 2
 # Nets: 0
 # Errors: 0
 # Warnings: 0
 # Rules: 0
 # Violations: 0
+# Inferred voltages: 0 Unknown voltage nets: 0 Rail coverage: UNKNOWN 0%
 # Wrote architon-report.json
+# exit code: 0
 
 rv scan examples/bom/bom.csv --map examples/mapping.yaml
 # Wrote architon-report.json
@@ -158,6 +164,7 @@ Core commands:
 ```text
 rv check <file.yaml>       Run deterministic analysis
 rv scan <path>             Import BOM CSV, KiCad .net, or project directory and emit DesignIR report JSON
+rv init                    Create .architon metadata or write a starter robot spec
 rv version                 Show installed version
 rv check --output json     Emit JSON findings to stdout
 rv --help                  Show all commands and flags
@@ -186,6 +193,7 @@ rv scan examples/bom/bom.csv
 rv scan examples/bom/bom.csv --map examples/mapping.yaml
 rv scan examples/bom/bom.csv --out my-report.json
 rv scan exports/project.net --meta .architon/meta.yaml
+rv scan exports/project.net --meta .architon/meta.yaml --rails
 
 # KiCad project folder scan (demo repo)
 git clone https://github.com/badimirzai/architon-kicad-demo.git demos
@@ -239,7 +247,7 @@ For a project directory scan, Architon auto-discovers `.architon/meta.yaml`:
 rv scan .
 ```
 
-For now, voltages and component limits come from `meta.yaml`. Future releases may infer safe values from net names and KiCad fields.
+Architon deterministically infers obvious rail voltages from net names, then enriches that with metadata sources and regulator outputs from `meta.yaml`. Component limits still come from metadata.
 
 Minimal voltage-rule metadata:
 
@@ -266,19 +274,23 @@ Example overvoltage output:
 ```text
 ARCHITON SCAN
 Target: exports/project.net
+Result: FAIL — scan violations detected
 Parts: 3
 Nets: 3
 Errors: 0
 Warnings: 0
 Rules: 1
 Violations: 1
+Inferred voltages: 2 Unknown voltage nets: 0 Rail coverage: HIGH 100%
 Rule findings:
 - ERROR RULE_OVERVOLTAGE: U1 pin 1 on net /+5V is 5.00V (max 3.30V)
 Wrote architon-report.json
-scan completed with 1 violation(s); wrote architon-report.json
+exit code: 2
 ```
 
 `Errors` are parse/import errors. Rule failures are reported as `Violations`.
+
+Use `--explain-rails` or `--rails` to print deterministic rail inference details, including voltage, confidence level, confidence score, source, and rail coverage.
 
 Default output path: `architon-report.json`.
 
@@ -354,7 +366,7 @@ rv check --warn-as-error robot.yaml
 
 Architon produces deterministic structured reports for automation.
 
-Default output path:
+Default scan output path:
 
 ```bash
 architon-report.json
@@ -363,14 +375,15 @@ architon-report.json
 Custom output path:
 
 ```bash
-rv check robot.yaml --out report.json
+rv check robot.yaml --output json --out-file report.json
 rv scan bom.csv --out report.json
 ```
 
 The report includes:
 - summary counts
-- violations / warnings / notes
-- normalized architecture model (DesignIR for scans, including nets when imported)
+- findings for `rv check`, or scan `rules` for `rv scan`
+- normalized DesignIR for scans, including nets when imported
+- rail inference, rail coverage, and voltage-finding provenance for netlist-backed scans
 
 Exit codes indicate pass/fail. The JSON report provides detailed structured results for CI integration and tooling.
 
@@ -412,24 +425,26 @@ On parse failures, the report still includes `report_version`, `design_ir.versio
 
 ```json
 {
-  "report_version": "0",
+  "spec_file": "robot.yaml",
   "summary": {
-    "input_file": "robot.yaml",
-    "violations": 1,
+    "errors": 1,
     "warnings": 2,
-    "notes": 1,
-    "has_failures": true
+    "infos": 1,
+    "exit_code": 2
   },
-  "violations": [
+  "findings": [
     {
-      "rule": "DRV_SUPPLY_RANGE",
-      "severity": "error",
+      "id": "DRV_SUPPLY_RANGE",
+      "severity": "ERROR",
       "message": "battery voltage exceeds driver supply range",
-      "fix": "Use compatible driver or adjust battery voltage"
+      "path": "power.battery.voltage_v",
+      "location": {
+        "line": 5,
+        "column": 5
+      },
+      "meta": {}
     }
-  ],
-  "warnings": [],
-  "notes": []
+  ]
 }
 ```
 
@@ -513,8 +528,8 @@ exit code: 2
 
 Architon is deterministic by design:
 - No AI
-- No guessing
 - No probabilistic inference
+- No hidden inference; rail inference is reported with source, confidence, and warnings
 - No hallucination
 
 Validation operates only on the specification and part data you provide.
@@ -529,6 +544,7 @@ The same input always produces the same result.
 `summary.delimiter` is set for BOM scans and uses one of `","`, `";"`, or `"\t"`.
 `summary.nets` is set when netlist data is present.
 `summary.next_steps` appears only when parse failures are present.
+Netlist-backed scan reports may include `derived.net_voltages`, `derived.inferred_net_voltages`, `derived.unknown_voltage_nets`, `derived.rail_inferences`, `derived.rail_coverage`, and optional `rules[].inference` provenance.
 
 Human-readable output is colorized in TTY environments. Disable with `--no-color` or `NO_COLOR=1`.
 
@@ -566,6 +582,7 @@ BOM ingestion and normalization (`rv scan`):
 - Deterministic project-folder scan (`rv scan .`) with BOM + netlist auto-detection
 - Deterministic BOM + netlist merge into one DesignIR
 - Metadata-backed voltage propagation and overvoltage rule findings for netlist scans
+- Deterministic rail voltage inference, confidence reporting, and rail coverage metrics
 - Automatic delimiter detection (comma, semicolon, tab)
 - Deterministic DesignIR JSON generation
 - Parse error reporting with remediation guidance

--- a/README.md
+++ b/README.md
@@ -290,11 +290,44 @@ exit code: 2
 
 `Errors` are parse/import errors. Rule failures are reported as `Violations`.
 
-Use `--explain-rails` or `--rails` to print deterministic rail inference details, including voltage, confidence level, confidence score, source, and rail coverage.
+Use `--rails` to print deterministic rail inference details, including voltage, confidence level, confidence score, source, and rail coverage. `--explain-rails` remains supported as a legacy alias.
 
 Default output path: `architon-report.json`.
 
+### Rail inference and coverage
 
+Rail voltage inference is deterministic and transparent. Each inference includes source, confidence score, evidence, and warnings. Confidence score indicates the reliability of an inference. Coverage indicates how much of the design can be safely checked by voltage rules. Users can inspect details with `--rails`.
+
+```bash
+rv scan example.net
+```
+
+Expected output:
+
+```text
+Inferred voltages: 2 Unknown voltage nets: 1 Rail coverage: MEDIUM 67%
+```
+
+```bash
+rv scan example.net --rails
+```
+
+Example detail:
+
+```text
+Rail inference:
+
+- /+5V: 5.00V  HIGH   0.95  NET_NAME_EXACT
+- VIN:  UNKNOWN LOW    0.35  HEURISTIC
+
+Rail coverage:
+
+- Total nets: 3
+- Usable for rules: 2/3
+- Coverage: MEDIUM 67%
+```
+
+High coverage does not guarantee correctness. Coverage indicates how many rails can be evaluated reliably. Low coverage means some checks may be skipped.
 
 ---
 
@@ -309,36 +342,9 @@ Default output path: `architon-report.json`.
 | 2 | Rule violations detected. |
 | 3 | Tool execution failure, including scan parse errors where analysis could not complete reliably. |
 
-### Exit code 1 — Warnings
+Warnings should be reviewed. CI may allow exit code 1 or treat it as failure using `--warn-as-error`.
 
-Exit code 1 means Architon successfully analyzed the architecture and found one or more warnings, but no violations.
-
-Warnings indicate elevated risk or incomplete constraints, such as:
-- Missing current limits
-- Low electrical margin conditions
-- Incomplete architecture specification
-
-The architecture may still function, but warnings should be reviewed.
-CI may allow exit code 1 or treat it as failure using `--warn-as-error`.
-
-### Exit code 2 — Violations
-
-Exit code 2 means Architon successfully analyzed the input and found one or more violations (HARD STOPS / errors).
-This indicates the architecture or scanned design is invalid and must be fixed.
-
-### Exit code 3 — Tool failure
-
-Exit code 3 means Architon could not complete analysis. This is not an architecture or design-rule violation.
-It indicates an input or runtime problem, such as:
-- Invalid YAML syntax
-- Missing input file
-- Schema validation failure
-- Import or resolution failure
-- Internal tool error
-
-For `rv scan`, malformed BOM rows and other parse failures still write a report when possible, then exit 3. This separates bad input/export data from valid analysis that found design-rule violations.
-
-Exit codes 0–2 indicate successful analysis. Exit code 3 indicates analysis could not run.
+For `rv scan`, malformed BOM rows and other parse failures still write a report when possible, then exit 3.
 
 ---
 
@@ -526,11 +532,10 @@ exit code: 2
 
 ## Deterministic by design
 
-Architon is deterministic by design:
-- No AI
-- No probabilistic inference
-- No hidden inference; rail inference is reported with source, confidence, and warnings
-- No hallucination
+Architon performs deterministic analysis.
+Rail voltage inference is deterministic and transparent.
+Each inference includes source, confidence score, evidence, and warnings.
+No probabilistic models or network calls are used.
 
 Validation operates only on the specification and part data you provide.
 The same input always produces the same result.

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -63,6 +64,7 @@ Examples:
 			bomOverride, _ := cmd.Flags().GetString("bom")
 			netlistOverride, _ := cmd.Flags().GetString("netlist")
 			metaOverride, _ := cmd.Flags().GetString("meta")
+			explainRails, _ := cmd.Flags().GetBool("explain-rails")
 
 			resolvedInput, err := resolveScanInput(args[0], bomOverride, netlistOverride)
 			if err != nil {
@@ -75,7 +77,7 @@ Examples:
 			}
 
 			designReport := report.NewVerificationReport(design)
-			inferRes := infer.InferVoltagesFromNetNames(design)
+			nameInferRes := infer.InferVoltagesFromNetNames(design)
 
 			// -------------------------
 			// META: auto-discover + skeleton generation (directory scans only)
@@ -165,20 +167,28 @@ Examples:
 			// -------------------------
 			// VOLTAGE PROPAGATION + RULES
 			// -------------------------
-			initialVoltages := scanInitialVoltages(inferRes, metaObj)
+			initialVoltages := scanInitialVoltages(nameInferRes, metaObj)
 			propRes := propagate.Result{NetVoltages: map[string]propagate.NetVoltage{}}
 			if designReport.Summary.Nets > 0 && len(initialVoltages) > 0 {
 				propRes = propagate.Propagate(*design, *metaObj, initialVoltages)
 			}
+			// Build the report-facing inference after propagation so explicit
+			// metadata and regulator outputs can contribute provenance/confidence.
+			railInferRes := infer.InferVoltages(design, infer.VoltageInferenceOptions{
+				Evidence:  scanVoltageEvidence(propRes.NetVoltages),
+				Conflicts: propRes.Conflicts,
+			})
 
 			netVolts := scanReportNetVoltages(propRes.NetVoltages)
-			inferredNetVolts := scanReportInferredNetVoltages(inferRes)
-			unknownVoltageNets := scanReportUnknownVoltageNets(inferRes)
-			if len(netVolts) > 0 || len(inferredNetVolts) > 0 || len(unknownVoltageNets) > 0 || len(propRes.Conflicts) > 0 {
+			inferredNetVolts := scanReportInferredNetVoltages(nameInferRes)
+			unknownVoltageNets := scanReportUnknownVoltageNets(railInferRes)
+			railInferences := scanReportRailInferences(railInferRes)
+			if len(netVolts) > 0 || len(inferredNetVolts) > 0 || len(unknownVoltageNets) > 0 || len(railInferences) > 0 || len(propRes.Conflicts) > 0 {
 				designReport.Derived = &report.Derived{
 					NetVoltages:         netVolts,
 					InferredNetVoltages: inferredNetVolts,
 					UnknownVoltageNets:  unknownVoltageNets,
+					RailInferences:      railInferences,
 					Conflicts:           propRes.Conflicts,
 				}
 			}
@@ -239,7 +249,10 @@ Examples:
 			fmt.Fprintf(cmd.OutOrStdout(), "Warnings: %d\n", designReport.Summary.ParseWarningsCount)
 			fmt.Fprintf(cmd.OutOrStdout(), "Rules: %d\n", designReport.Summary.Rules)
 			fmt.Fprintf(cmd.OutOrStdout(), "Violations: %d\n", scanRuleViolationCount(designReport))
-			fmt.Fprintf(cmd.OutOrStdout(), "Inferred voltages: %d Unknown voltage nets: %d\n", len(inferRes.Voltages), len(inferRes.Unknowns))
+			fmt.Fprintf(cmd.OutOrStdout(), "Inferred voltages: %d Unknown voltage nets: %d\n", len(nameInferRes.Voltages), len(railInferRes.Unknowns))
+			if explainRails {
+				scanPrintRailInferences(cmd.OutOrStdout(), railInferences)
+			}
 
 			if len(designReport.Rules) > 0 {
 				fmt.Fprintf(cmd.OutOrStdout(), "Rule findings:\n")
@@ -297,6 +310,7 @@ Examples:
 	cmd.Flags().String("bom", "", "Override BOM file path when scanning a project directory")
 	cmd.Flags().String("netlist", "", "Override netlist file path when scanning a project directory")
 	cmd.Flags().String("meta", "", "Override meta file path (default: .architon/meta.yaml if present; auto-generated if missing)")
+	cmd.Flags().Bool("explain-rails", false, "Print rail voltage inference provenance and confidence")
 	return cmd
 }
 
@@ -732,6 +746,48 @@ func scanReportNetVoltages(netVoltages map[string]propagate.NetVoltage) []report
 	return out
 }
 
+// scanVoltageEvidence converts propagated net voltages into inference evidence.
+// Only user-supplied sources and regulator outputs are promoted here because
+// plain "initial" entries already came from net-name inference.
+func scanVoltageEvidence(netVoltages map[string]propagate.NetVoltage) []infer.VoltageEvidence {
+	out := make([]infer.VoltageEvidence, 0, len(netVoltages))
+	for _, nv := range netVoltages {
+		source := strings.TrimSpace(nv.Source)
+		switch {
+		case source == "source":
+			out = append(out, infer.VoltageEvidence{
+				NetName:   nv.Net,
+				Voltage:   nv.Voltage,
+				Source:    infer.SourceUserOverride,
+				BaseScore: 1.00,
+				Evidence:  fmt.Sprintf("user override set rail %q to %.2fV", nv.Net, nv.Voltage),
+			})
+		case strings.HasPrefix(source, "regulator:"):
+			ref := strings.TrimSpace(strings.TrimPrefix(source, "regulator:"))
+			if ref == "" {
+				ref = "unknown"
+			}
+			out = append(out, infer.VoltageEvidence{
+				NetName:   nv.Net,
+				Voltage:   nv.Voltage,
+				Source:    infer.SourceRegulatorOutput,
+				BaseScore: 0.90,
+				Evidence:  fmt.Sprintf("regulator %s output mapped to rail %q at %.2fV", ref, nv.Net, nv.Voltage),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].NetName != out[j].NetName {
+			return out[i].NetName < out[j].NetName
+		}
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		return out[i].Voltage < out[j].Voltage
+	})
+	return out
+}
+
 func scanReportInferredNetVoltages(inferRes infer.Result) []report.NetVoltage {
 	out := make([]report.NetVoltage, 0, len(inferRes.Voltages))
 	for _, inferred := range inferRes.Voltages {
@@ -760,6 +816,68 @@ func scanReportUnknownVoltageNets(inferRes infer.Result) []report.UnknownVoltage
 		return out[i].Reason < out[j].Reason
 	})
 	return out
+}
+
+// scanReportRailInferences keeps the JSON stable by reporting rails with actual
+// voltage evidence and named unknown rail-like nets, while omitting arbitrary
+// non-power signals that only produced UNKNOWN/no-evidence records.
+func scanReportRailInferences(inferRes infer.Result) []infer.VoltageInference {
+	unknownNets := map[string]struct{}{}
+	for _, unknown := range inferRes.Unknowns {
+		unknownNets[unknown.Net] = struct{}{}
+	}
+
+	out := make([]infer.VoltageInference, 0, len(inferRes.Inferences))
+	for _, inference := range inferRes.Inferences {
+		if inference.Voltage == nil && len(inference.Evidence) == 0 {
+			if _, ok := unknownNets[inference.NetName]; !ok {
+				continue
+			}
+		}
+		out = append(out, inference)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].NetName != out[j].NetName {
+			return out[i].NetName < out[j].NetName
+		}
+		return out[i].Source < out[j].Source
+	})
+	return out
+}
+
+// scanPrintRailInferences renders the same stable inference data as JSON in a
+// compact human form for rv scan --explain-rails.
+func scanPrintRailInferences(out io.Writer, inferences []infer.VoltageInference) {
+	if len(inferences) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "Rail inferences:")
+	for i, inference := range inferences {
+		if i > 0 {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "Rail: %s\n", inference.NetName)
+		if inference.Voltage == nil {
+			fmt.Fprintln(out, "Voltage: unknown")
+		} else {
+			fmt.Fprintf(out, "Voltage: %.2fV\n", *inference.Voltage)
+		}
+		fmt.Fprintf(out, "Source: %s\n", inference.Source)
+		fmt.Fprintf(out, "Confidence: %s\n", inference.ConfidenceLevel)
+		fmt.Fprintf(out, "Score: %.2f\n", inference.ConfidenceScore)
+		if len(inference.Evidence) > 0 {
+			fmt.Fprintln(out, "Evidence:")
+			for _, evidence := range inference.Evidence {
+				fmt.Fprintf(out, "- %s\n", evidence)
+			}
+		}
+		if len(inference.Warnings) > 0 {
+			fmt.Fprintln(out, "Warnings:")
+			for _, warning := range inference.Warnings {
+				fmt.Fprintf(out, "- %s\n", warning)
+			}
+		}
+	}
 }
 
 func scanPrepareAutoMeta(m *meta.Meta) *meta.Meta {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/badimirzai/architon-cli/internal/ir"
 	"github.com/badimirzai/architon-cli/internal/meta"
 	"github.com/badimirzai/architon-cli/internal/propagate"
+	"github.com/badimirzai/architon-cli/internal/rails"
 	"github.com/badimirzai/architon-cli/internal/report"
 	"github.com/badimirzai/architon-cli/internal/rules"
 	"github.com/badimirzai/architon-cli/internal/ui"
@@ -65,6 +66,8 @@ Examples:
 			netlistOverride, _ := cmd.Flags().GetString("netlist")
 			metaOverride, _ := cmd.Flags().GetString("meta")
 			explainRails, _ := cmd.Flags().GetBool("explain-rails")
+			railsAlias, _ := cmd.Flags().GetBool("rails")
+			explainRails = explainRails || railsAlias
 
 			resolvedInput, err := resolveScanInput(args[0], bomOverride, netlistOverride)
 			if err != nil {
@@ -183,12 +186,15 @@ Examples:
 			inferredNetVolts := scanReportInferredNetVoltages(nameInferRes)
 			unknownVoltageNets := scanReportUnknownVoltageNets(railInferRes)
 			railInferences := scanReportRailInferences(railInferRes)
-			if len(netVolts) > 0 || len(inferredNetVolts) > 0 || len(unknownVoltageNets) > 0 || len(railInferences) > 0 || len(propRes.Conflicts) > 0 {
+			railCoverage := rails.SummarizeRailCoverage(design, railInferRes.Inferences)
+			inferencesByNet := scanInferenceByNet(railInferRes.Inferences)
+			if designReport.Summary.Nets > 0 || len(netVolts) > 0 || len(inferredNetVolts) > 0 || len(unknownVoltageNets) > 0 || len(railInferences) > 0 || len(propRes.Conflicts) > 0 {
 				designReport.Derived = &report.Derived{
 					NetVoltages:         netVolts,
 					InferredNetVoltages: inferredNetVolts,
 					UnknownVoltageNets:  unknownVoltageNets,
 					RailInferences:      railInferences,
+					RailCoverage:        railCoverage,
 					Conflicts:           propRes.Conflicts,
 				}
 			}
@@ -196,17 +202,21 @@ Examples:
 			if len(propRes.Conflicts) > 0 {
 				// Conflicts are violations (severity error => exit 2)
 				for _, c := range propRes.Conflicts {
-					designReport.Rules = append(designReport.Rules, report.RuleResult{
+					result := report.RuleResult{
 						ID:       "RULE_VOLTAGE_CONFLICT",
 						Severity: "error",
 						Message:  c,
-					})
+					}
+					if inference, ok := inferencesByNet[scanConflictNetName(c)]; ok {
+						result.Inference = scanReportInferenceProvenance(inference)
+					}
+					designReport.Rules = append(designReport.Rules, result)
 				}
 			}
 
 			if metaLoaded && len(propRes.NetVoltages) > 0 {
 				// Overvoltage violations
-				designReport.Rules = append(designReport.Rules, rules.Overvoltage(design, metaObj, propRes.NetVoltages)...)
+				designReport.Rules = append(designReport.Rules, rules.OvervoltageWithInferences(design, metaObj, propRes.NetVoltages, inferencesByNet)...)
 			}
 
 			if len(designReport.Rules) > 0 {
@@ -249,9 +259,9 @@ Examples:
 			fmt.Fprintf(cmd.OutOrStdout(), "Warnings: %d\n", designReport.Summary.ParseWarningsCount)
 			fmt.Fprintf(cmd.OutOrStdout(), "Rules: %d\n", designReport.Summary.Rules)
 			fmt.Fprintf(cmd.OutOrStdout(), "Violations: %d\n", scanRuleViolationCount(designReport))
-			fmt.Fprintf(cmd.OutOrStdout(), "Inferred voltages: %d Unknown voltage nets: %d\n", len(nameInferRes.Voltages), len(railInferRes.Unknowns))
+			fmt.Fprintf(cmd.OutOrStdout(), "Inferred voltages: %d Unknown voltage nets: %d Rail coverage: %s\n", len(nameInferRes.Voltages), len(railInferRes.Unknowns), rails.FormatRailCoverage(railCoverage))
 			if explainRails {
-				scanPrintRailInferences(cmd.OutOrStdout(), railInferences)
+				scanPrintRailInferences(cmd.OutOrStdout(), railInferences, railCoverage)
 			}
 
 			if len(designReport.Rules) > 0 {
@@ -311,6 +321,7 @@ Examples:
 	cmd.Flags().String("netlist", "", "Override netlist file path when scanning a project directory")
 	cmd.Flags().String("meta", "", "Override meta file path (default: .architon/meta.yaml if present; auto-generated if missing)")
 	cmd.Flags().Bool("explain-rails", false, "Print rail voltage inference provenance and confidence")
+	cmd.Flags().Bool("rails", false, "Alias for --explain-rails")
 	return cmd
 }
 
@@ -845,39 +856,43 @@ func scanReportRailInferences(inferRes infer.Result) []infer.VoltageInference {
 	return out
 }
 
+func scanInferenceByNet(inferences []infer.VoltageInference) map[string]infer.VoltageInference {
+	out := make(map[string]infer.VoltageInference, len(inferences))
+	for _, inference := range inferences {
+		netName := strings.TrimSpace(inference.NetName)
+		if netName == "" {
+			continue
+		}
+		out[netName] = inference
+	}
+	return out
+}
+
+func scanReportInferenceProvenance(inference infer.VoltageInference) *report.InferenceProvenance {
+	return &report.InferenceProvenance{
+		NetName:         inference.NetName,
+		Source:          inference.Source,
+		ConfidenceScore: inference.ConfidenceScore,
+		ConfidenceLevel: inference.ConfidenceLevel,
+	}
+}
+
+func scanConflictNetName(message string) string {
+	const prefix = "Voltage conflict on net "
+	if !strings.HasPrefix(message, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(message, prefix)
+	if idx := strings.Index(rest, ":"); idx >= 0 {
+		rest = rest[:idx]
+	}
+	return strings.TrimSpace(rest)
+}
+
 // scanPrintRailInferences renders the same stable inference data as JSON in a
 // compact human form for rv scan --explain-rails.
-func scanPrintRailInferences(out io.Writer, inferences []infer.VoltageInference) {
-	if len(inferences) == 0 {
-		return
-	}
-	fmt.Fprintln(out, "Rail inferences:")
-	for i, inference := range inferences {
-		if i > 0 {
-			fmt.Fprintln(out)
-		}
-		fmt.Fprintf(out, "Rail: %s\n", inference.NetName)
-		if inference.Voltage == nil {
-			fmt.Fprintln(out, "Voltage: unknown")
-		} else {
-			fmt.Fprintf(out, "Voltage: %.2fV\n", *inference.Voltage)
-		}
-		fmt.Fprintf(out, "Source: %s\n", inference.Source)
-		fmt.Fprintf(out, "Confidence: %s\n", inference.ConfidenceLevel)
-		fmt.Fprintf(out, "Score: %.2f\n", inference.ConfidenceScore)
-		if len(inference.Evidence) > 0 {
-			fmt.Fprintln(out, "Evidence:")
-			for _, evidence := range inference.Evidence {
-				fmt.Fprintf(out, "- %s\n", evidence)
-			}
-		}
-		if len(inference.Warnings) > 0 {
-			fmt.Fprintln(out, "Warnings:")
-			for _, warning := range inference.Warnings {
-				fmt.Fprintf(out, "- %s\n", warning)
-			}
-		}
-	}
+func scanPrintRailInferences(out io.Writer, inferences []infer.VoltageInference, summary rails.RailCoverageSummary) {
+	fmt.Fprint(out, rails.FormatRailExplanations(inferences, summary))
 }
 
 func scanPrepareAutoMeta(m *meta.Meta) *meta.Meta {

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -49,6 +49,15 @@ type scanReport struct {
 			Net    string `json:"net"`
 			Reason string `json:"reason"`
 		} `json:"unknown_voltage_nets"`
+		RailInferences []struct {
+			NetName         string   `json:"net_name"`
+			Voltage         *float64 `json:"voltage"`
+			Source          string   `json:"source"`
+			ConfidenceScore float64  `json:"confidence_score"`
+			ConfidenceLevel string   `json:"confidence_level"`
+			Evidence        []string `json:"evidence"`
+			Warnings        []string `json:"warnings"`
+		} `json:"rail_inferences"`
 	} `json:"derived"`
 }
 
@@ -494,8 +503,8 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 			if nv.Voltage != 5.0 {
 				t.Fatalf("expected /+5V inferred as 5.0, got %v", nv.Voltage)
 			}
-			if nv.Source != "net_name" {
-				t.Fatalf("expected inferred source net_name, got %q", nv.Source)
+			if nv.Source != "NET_NAME_EXACT" {
+				t.Fatalf("expected inferred source NET_NAME_EXACT, got %q", nv.Source)
 			}
 		}
 	}
@@ -511,6 +520,56 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 	}
 	if report.Derived.UnknownVoltageNets[0].Reason != "ambiguous power net name" {
 		t.Fatalf("expected ambiguous power reason, got %q", report.Derived.UnknownVoltageNets[0].Reason)
+	}
+
+	var foundRailInference bool
+	for _, inference := range report.Derived.RailInferences {
+		if inference.NetName != "/+5V" {
+			continue
+		}
+		foundRailInference = true
+		if inference.Voltage == nil || *inference.Voltage != 5.0 {
+			t.Fatalf("expected /+5V rail inference voltage 5.0, got %+v", inference.Voltage)
+		}
+		if inference.Source != "NET_NAME_EXACT" {
+			t.Fatalf("expected /+5V rail inference source NET_NAME_EXACT, got %q", inference.Source)
+		}
+		if inference.ConfidenceLevel != "HIGH" || inference.ConfidenceScore != 0.95 {
+			t.Fatalf("expected /+5V high confidence score 0.95, got %+v", inference)
+		}
+	}
+	if !foundRailInference {
+		t.Fatalf("expected /+5V rail inference in report, got %+v", report.Derived.RailInferences)
+	}
+}
+
+func TestScan_ExplainRailsPrintsInferenceDetails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stdout, err := runScanCommand(t, tmpDir, kicadFixturePath(t, filepath.Join("overvoltage", "netlist_overvoltage.net")), "--explain-rails")
+	if err != nil {
+		t.Fatalf("expected netlist scan with inferred voltages to succeed, got %v", err)
+	}
+	if !strings.Contains(stdout, "Rail inferences:\n") {
+		t.Fatalf("expected rail inference header, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Rail: /+5V\n") {
+		t.Fatalf("expected /+5V rail line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Voltage: 5.00V\n") {
+		t.Fatalf("expected voltage line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Source: NET_NAME_EXACT\n") {
+		t.Fatalf("expected source line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Confidence: HIGH\n") {
+		t.Fatalf("expected confidence line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Score: 0.95\n") {
+		t.Fatalf("expected score line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "- matched exact voltage pattern \"/+5V\"\n") {
+		t.Fatalf("expected evidence line, got %q", stdout)
 	}
 }
 

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -34,6 +34,17 @@ type scanReport struct {
 			Name string `json:"name"`
 		} `json:"nets"`
 	} `json:"design_ir"`
+	Rules []struct {
+		ID        string `json:"id"`
+		Severity  string `json:"severity"`
+		Message   string `json:"message"`
+		Inference *struct {
+			NetName         string  `json:"net_name"`
+			Source          string  `json:"source"`
+			ConfidenceScore float64 `json:"confidence_score"`
+			ConfidenceLevel string  `json:"confidence_level"`
+		} `json:"inference"`
+	} `json:"rules"`
 	Derived *struct {
 		NetVoltages []struct {
 			Net     string  `json:"net"`
@@ -58,6 +69,20 @@ type scanReport struct {
 			Evidence        []string `json:"evidence"`
 			Warnings        []string `json:"warnings"`
 		} `json:"rail_inferences"`
+		RailCoverage struct {
+			TotalNets           int      `json:"total_nets"`
+			RailsWithVoltage    int      `json:"rails_with_voltage"`
+			RailsUnknown        int      `json:"rails_unknown"`
+			HighConfidence      int      `json:"high_confidence"`
+			MediumConfidence    int      `json:"medium_confidence"`
+			LowConfidence       int      `json:"low_confidence"`
+			UnknownConfidence   int      `json:"unknown_confidence"`
+			CoverageRatio       float64  `json:"coverage_ratio"`
+			HighConfidenceRatio float64  `json:"high_confidence_ratio"`
+			UsableForRulesRatio float64  `json:"usable_for_rules_ratio"`
+			OverallLevel        string   `json:"overall_level"`
+			Warnings            []string `json:"warnings"`
+		} `json:"rail_coverage"`
 	} `json:"derived"`
 }
 
@@ -487,8 +512,11 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected netlist scan with inferred voltages to succeed, got %v", err)
 	}
-	if !strings.Contains(stdout, "Inferred voltages: 2 Unknown voltage nets: 1\n") {
+	if !strings.Contains(stdout, "Inferred voltages: 2 Unknown voltage nets: 1 Rail coverage: LOW 67%\n") {
 		t.Fatalf("expected voltage inference counts, got %q", stdout)
+	}
+	if strings.Contains(stdout, "Rail inference:\n") {
+		t.Fatalf("expected default output to stay compact, got %q", stdout)
 	}
 
 	report := readScanReport(t, filepath.Join(tmpDir, defaultScanReportPath))
@@ -541,35 +569,61 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 	if !foundRailInference {
 		t.Fatalf("expected /+5V rail inference in report, got %+v", report.Derived.RailInferences)
 	}
+	if report.Derived.RailCoverage.TotalNets != 3 {
+		t.Fatalf("expected rail coverage total nets 3, got %+v", report.Derived.RailCoverage)
+	}
+	if report.Derived.RailCoverage.RailsWithVoltage != 2 || report.Derived.RailCoverage.RailsUnknown != 1 {
+		t.Fatalf("unexpected rail coverage counts: %+v", report.Derived.RailCoverage)
+	}
+	if report.Derived.RailCoverage.UsableForRulesRatio != 0.6667 {
+		t.Fatalf("expected usable ratio 0.6667, got %+v", report.Derived.RailCoverage)
+	}
 }
 
 func TestScan_ExplainRailsPrintsInferenceDetails(t *testing.T) {
 	tmpDir := t.TempDir()
+	metaPath := filepath.Join(tmpDir, "meta.yaml")
+	writeScanTestFile(t, metaPath, `version: "0"
+sources:
+  - net: /VBAT
+    voltage: 24.0
+regulators:
+  - ref: U2
+    in_pin: "1"
+    out_pin: "3"
+    out_voltage: 5.0
+components:
+  - ref: U1
+    max_voltage: 6.0
+`)
 
-	stdout, err := runScanCommand(t, tmpDir, kicadFixturePath(t, filepath.Join("overvoltage", "netlist_overvoltage.net")), "--explain-rails")
+	stdout, err := runScanCommand(t, tmpDir, kicadFixturePath(t, filepath.Join("overvoltage", "netlist_overvoltage.net")), "--meta", metaPath, "--explain-rails")
 	if err != nil {
 		t.Fatalf("expected netlist scan with inferred voltages to succeed, got %v", err)
 	}
-	if !strings.Contains(stdout, "Rail inferences:\n") {
+	if !strings.Contains(stdout, "Rail inference:\n") {
 		t.Fatalf("expected rail inference header, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "Rail: /+5V\n") {
+	if !strings.Contains(stdout, "- /+5V: 5.00V  HIGH   0.95  NET_NAME_EXACT\n") {
 		t.Fatalf("expected /+5V rail line, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "Voltage: 5.00V\n") {
-		t.Fatalf("expected voltage line, got %q", stdout)
+	if !strings.Contains(stdout, "- /VBAT: 24.00V HIGH   1.00  USER_OVERRIDE\n") {
+		t.Fatalf("expected /VBAT rail line, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "Source: NET_NAME_EXACT\n") {
-		t.Fatalf("expected source line, got %q", stdout)
+	if !strings.Contains(stdout, "- GND:   0.00V  HIGH   0.95  NET_NAME_EXACT\n") {
+		t.Fatalf("expected GND rail line, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "Confidence: HIGH\n") {
-		t.Fatalf("expected confidence line, got %q", stdout)
+	if !strings.Contains(stdout, "Rail coverage:\n") {
+		t.Fatalf("expected rail coverage section, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "Score: 0.95\n") {
-		t.Fatalf("expected score line, got %q", stdout)
+	if !strings.Contains(stdout, "- Total nets: 3\n") {
+		t.Fatalf("expected total nets line, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "- matched exact voltage pattern \"/+5V\"\n") {
-		t.Fatalf("expected evidence line, got %q", stdout)
+	if !strings.Contains(stdout, "- Usable for rules: 3/3\n") {
+		t.Fatalf("expected usable line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "- Coverage: HIGH 100%\n") {
+		t.Fatalf("expected coverage line, got %q", stdout)
 	}
 }
 
@@ -600,6 +654,23 @@ components:
 	}
 	if !strings.Contains(stdout, "U1 pin 1 on net /+5V is 5.00V (max 3.30V)") {
 		t.Fatalf("expected inferred /+5V overvoltage, got %q", stdout)
+	}
+
+	report := readScanReport(t, filepath.Join(tmpDir, defaultScanReportPath))
+	if len(report.Rules) != 1 {
+		t.Fatalf("expected one rule finding, got %+v", report.Rules)
+	}
+	if report.Rules[0].Inference == nil {
+		t.Fatalf("expected overvoltage finding inference provenance, got %+v", report.Rules[0])
+	}
+	if report.Rules[0].Inference.NetName != "/+5V" {
+		t.Fatalf("expected inference net /+5V, got %+v", report.Rules[0].Inference)
+	}
+	if report.Rules[0].Inference.Source != "NET_NAME_EXACT" {
+		t.Fatalf("expected inference source NET_NAME_EXACT, got %+v", report.Rules[0].Inference)
+	}
+	if report.Rules[0].Inference.ConfidenceLevel != "HIGH" || report.Rules[0].Inference.ConfidenceScore != 0.95 {
+		t.Fatalf("expected high confidence inference, got %+v", report.Rules[0].Inference)
 	}
 }
 

--- a/cmd/scan_violation_test.go
+++ b/cmd/scan_violation_test.go
@@ -66,6 +66,9 @@ func TestScan_OvervoltageYieldsExit2(t *testing.T) {
 	if !strings.Contains(output, "Violations: 1\n") {
 		t.Fatalf("expected output to show 1 violation\n%s", output)
 	}
+	if !strings.Contains(output, "Inferred voltages: 2 Unknown voltage nets: 0 Rail coverage: HIGH 100%\n") {
+		t.Fatalf("expected output to show compact rail coverage\n%s", output)
+	}
 	if !strings.Contains(output, "RULE_OVERVOLTAGE") {
 		t.Fatalf("expected output to show RULE_OVERVOLTAGE\n%s", output)
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ Primary command:
 - `rv scan . --bom bom/bom.csv --netlist exports/project.net`
 - `rv scan <bom.csv> --out my-report.json`
 - `rv scan <netlist.net> --meta .architon/meta.yaml`
-- `rv scan <netlist.net> --rails` (`--explain-rails` alias)
+- `rv scan <netlist.net> --rails`
 
 Output modes:
 
@@ -127,21 +127,7 @@ Output modes:
   - `rules`
   - `derived` voltage inference and rail coverage data when netlist data is present
 
-Exit behavior for `rv check`:
-
-- `0`: no `ERROR` or `WARN` findings (`INFO` notes allowed)
-- `1`: one or more `WARN` findings and no `ERROR` findings
-- `2`: one or more `ERROR` findings, regardless of warnings
-- `3`: parse/decode/resolve/import/schema/IO failures
-
-With `--warn-as-error`, warning-only results also return `2`.
-
-Exit behavior for `rv scan`:
-
-- `0`: clean/info-only scan
-- `1`: warnings detected and no violations
-- `2`: one or more rule violations
-- `3`: tool execution failure, including scan parse errors
+Exit behavior is documented in the canonical exit code table in `README.md`.
 
 `rv scan` writes `architon-report.json` with `report_version`, `design_ir.version`, and:
 
@@ -165,7 +151,7 @@ Successful CLI output also prints a short deterministic terminal summary with:
 - compact rail coverage counts and level
 - `Detected BOM` / `Detected Netlist` for directory auto-detection
 
-`--explain-rails` or `--rails` prints the sorted rail inference table with voltage, confidence level, confidence score, source, warnings, and rail coverage summary.
+`--rails` prints the sorted rail inference table with voltage, confidence level, confidence score, source, warnings, and rail coverage summary. `--explain-rails` remains supported as a legacy alias.
 
 Example success snippet:
 
@@ -213,12 +199,12 @@ Example failure snippet:
 
 ## Deterministic design philosophy
 
-The engine is intentionally non-probabilistic.
+Architon performs deterministic analysis.
+Rail voltage inference is deterministic and transparent.
+Each inference includes source, confidence score, evidence, and warnings.
+No probabilistic models or network calls are used.
 
-- No AI/model inference
-- No remote lookups during validation
-- Any deterministic rail-name heuristic is reported with source, confidence, and warnings
-- Same input spec or scan input + same metadata/part library -> same output findings and exit code
+Same input spec or scan input + same metadata/part library -> same output findings and exit code.
 
 This allows CI gating, reproducible audits, and traceable engineering review.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,10 @@ spec.yaml
   -> findings report
   -> CLI renderer (human or JSON) + exit code
 
-bom.csv
-  -> KiCad BOM importer
+bom.csv / project.net / project directory
+  -> KiCad BOM and/or netlist importer
   -> DesignIR (stable internal model)
+  -> deterministic rail inference + metadata-backed voltage rules
   -> deterministic report payload
   -> architon-report.json
 ```
@@ -112,6 +113,8 @@ Primary command:
 - `rv scan .`
 - `rv scan . --bom bom/bom.csv --netlist exports/project.net`
 - `rv scan <bom.csv> --out my-report.json`
+- `rv scan <netlist.net> --meta .architon/meta.yaml`
+- `rv scan <netlist.net> --rails` (`--explain-rails` alias)
 
 Output modes:
 
@@ -122,6 +125,7 @@ Output modes:
   - `summary`
   - `design_ir`
   - `rules`
+  - `derived` voltage inference and rail coverage data when netlist data is present
 
 Exit behavior for `rv check`:
 
@@ -134,26 +138,34 @@ With `--warn-as-error`, warning-only results also return `2`.
 
 Exit behavior for `rv scan`:
 
-- `0`: success
-- `1`: rule violations
-- `2`: parse errors
-- `3`: tool failure / internal error
+- `0`: clean/info-only scan
+- `1`: warnings detected and no violations
+- `2`: one or more rule violations
+- `3`: tool execution failure, including scan parse errors
 
 `rv scan` writes `architon-report.json` with `report_version`, `design_ir.version`, and:
 
 - `summary.delimiter` for BOM-backed scans
 - `summary.nets` and `design_ir.nets` for netlist-backed scans
 - `summary.next_steps` only on parse failure
+- `derived.net_voltages`, `derived.inferred_net_voltages`, `derived.unknown_voltage_nets`, `derived.rail_inferences`, and `derived.rail_coverage` when voltage inference data is present
+- optional `rules[].inference` provenance for voltage-based findings
 
 Successful CLI output also prints a short deterministic terminal summary with:
 
 - `ARCHITON SCAN`
 - `Target`
+- `Result`
 - `Parts`
 - `Nets`
 - `Errors`
 - `Warnings`
+- `Rules`
+- `Violations`
+- compact rail coverage counts and level
 - `Detected BOM` / `Detected Netlist` for directory auto-detection
+
+`--explain-rails` or `--rails` prints the sorted rail inference table with voltage, confidence level, confidence score, source, warnings, and rail coverage summary.
 
 Example success snippet:
 
@@ -195,16 +207,18 @@ Example failure snippet:
 - `internal/importers/kicad`: deterministic KiCad BOM CSV ingestion, header mapping, and KiCad `.net` S-expression parsing
 - `cmd/scan.go`: deterministic single-file or project-directory scan input resolution
 - `internal/ir`: deterministic BOM + netlist merge into one project-level DesignIR
+- `internal/infer`: deterministic net-name and metadata-enriched rail voltage inference
+- `internal/rails`: pure rail coverage summary and terminal explanation formatting
 - `internal/report`: deterministic scan report JSON builder/writer
 
 ## Deterministic design philosophy
 
 The engine is intentionally non-probabilistic.
 
-- No model inference
+- No AI/model inference
 - No remote lookups during validation
-- No hidden heuristics
-- Same input spec + same part library -> same output findings and exit code
+- Any deterministic rail-name heuristic is reported with source, confidence, and warnings
+- Same input spec or scan input + same metadata/part library -> same output findings and exit code
 
 This allows CI gating, reproducible audits, and traceable engineering review.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -36,14 +36,7 @@ This order is stable and produces reproducible findings for identical input.
 - `WARN`: elevated risk or low margin
 - `ERROR`: deterministic contract violation
 
-## Exit codes (`rv check`)
-
-- `0`: analysis completed with no `ERROR` or `WARN` findings (`INFO` notes are allowed)
-- `1`: one or more `WARN` findings and no `ERROR` findings
-- `2`: one or more `ERROR` findings, regardless of warnings
-- `3`: parse/decode/resolve/import/schema/IO failure path
-
-With `--warn-as-error`, warning-only results also return `2`.
+Exit behavior is documented in `README.md`.
 
 ## Rule catalog
 
@@ -119,7 +112,7 @@ Netlist-backed scans can run deterministic voltage rules when rail voltages are 
 
 Voltage-based findings include inference provenance when available: net name, source, confidence score, and confidence level.
 
-## Determinism guarantees
+## Determinism contract
 
 Given the same:
 
@@ -129,7 +122,10 @@ Given the same:
 
 the engine returns the same findings and exit code.
 
-No network access or probabilistic scoring is part of rule evaluation.
+Architon performs deterministic analysis.
+Rail voltage inference is deterministic and transparent.
+Each inference includes source, confidence score, evidence, and warnings.
+No probabilistic models or network calls are used.
 
 ## Extensibility
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,8 +1,8 @@
 # Deterministic Rule System
 
-Architon CLI (rv) uses a deterministic rule engine implemented in `internal/validate/rules.go`.
+Architon CLI (rv) uses deterministic rule engines for YAML specs and KiCad scan data. `rv check` rules live in `internal/validate/rules.go`; scan voltage rules live under `internal/rules`.
 
-Rules evaluate only the resolved input specification and emit findings with explicit IDs.
+Rules evaluate only resolved local input data and emit findings with explicit IDs.
 
 ## Rule philosophy
 
@@ -46,6 +46,8 @@ This order is stable and produces reproducible findings for identical input.
 With `--warn-as-error`, warning-only results also return `2`.
 
 ## Rule catalog
+
+The catalog below covers `rv check`.
 
 ### Driver channel allocation
 
@@ -108,11 +110,20 @@ Rules:
 
 `address_hex` accepts decimal or `0x`-prefixed hex values.
 
+## Scan voltage rules (`rv scan`)
+
+Netlist-backed scans can run deterministic voltage rules when rail voltages are inferred from net names and/or supplied by `.architon/meta.yaml` / `--meta`.
+
+- `RULE_OVERVOLTAGE` (`ERROR`): component pin is connected to a net voltage above that component's metadata `max_voltage`
+- `RULE_VOLTAGE_CONFLICT` (`ERROR`): metadata, inferred, or propagated voltage evidence conflicts on a net
+
+Voltage-based findings include inference provenance when available: net name, source, confidence score, and confidence level.
+
 ## Determinism guarantees
 
 Given the same:
 
-- Spec file content
+- Spec file content, or scan input netlist/BOM and metadata
 - Part files resolved by search order
 - CLI options
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -151,7 +151,7 @@ Battery max-current precedence used by rules:
 - `motors[].count`
 - `motors[].stall_current_a`
 
-Missing required values cause resolve failures (exit code `3`) before rule findings are emitted.
+Missing required values cause resolve failures before rule findings are emitted.
 
 ## Parts system
 

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -1,31 +1,79 @@
 package infer
 
 import (
+	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/badimirzai/architon-cli/internal/ir"
 )
 
-const netNameSource = "net_name"
 const ambiguousPowerNetReason = "ambiguous power net name"
+const multipleCandidateVoltagesReason = "multiple candidate voltages detected"
+
+const (
+	SourceUserOverride          = "USER_OVERRIDE"
+	SourceNetNameExact          = "NET_NAME_EXACT"
+	SourceRegulatorOutput       = "REGULATOR_OUTPUT"
+	SourceSemanticAlias         = "SEMANTIC_ALIAS"
+	SourceWeakSemanticAlias     = "WEAK_SEMANTIC_ALIAS"
+	SourceAmbiguousNumericToken = "AMBIGUOUS_NUMERIC_TOKEN"
+	SourceUnknown               = "UNKNOWN"
+)
+
+const (
+	ConfidenceHigh    = "HIGH"
+	ConfidenceMedium  = "MEDIUM"
+	ConfidenceLow     = "LOW"
+	ConfidenceUnknown = "UNKNOWN"
+)
+
+const (
+	scoreUserOverride          = 1.00
+	scoreNetNameExact          = 0.95
+	scoreRegulatorOutput       = 0.90
+	scoreSemanticAlias         = 0.80
+	scoreWeakSemanticAlias     = 0.65
+	scoreAmbiguousNumericToken = 0.40
+	scoreUnknown               = 0.00
+)
 
 var (
 	decimalVoltagePattern = regexp.MustCompile(`^\+?([0-9]+(?:\.[0-9]+)?)V$`)
 	vDecimalPattern       = regexp.MustCompile(`^\+?([0-9]+)V([0-9]+)$`)
-	suffixVoltagePattern  = regexp.MustCompile(`^.+_([0-9]+(?:\.[0-9]+)?V|[0-9]+V[0-9]+)$`)
 )
 
 var ambiguousPowerNetNames = map[string]struct{}{
 	"VBAT":      {},
 	"VCC":       {},
+	"VDD":       {},
 	"VIN":       {},
 	"POWER":     {},
 	"PWR":       {},
 	"SUPPLY":    {},
 	"MOTOR_PWR": {},
+}
+
+var genericRailNameTokens = map[string]struct{}{
+	"VCC":    {},
+	"VDD":    {},
+	"VIN":    {},
+	"POWER":  {},
+	"PWR":    {},
+	"SUPPLY": {},
+}
+
+var knownSemanticAliases = map[string]float64{
+	"VBUS": 5.0,
+}
+
+var weakSemanticAliases = map[string]struct{}{
+	"VCC": {},
+	"VDD": {},
 }
 
 type InferredVoltage struct {
@@ -40,52 +88,354 @@ type UnknownVoltage struct {
 }
 
 type Result struct {
-	Voltages map[string]InferredVoltage
-	Unknowns []UnknownVoltage
+	Voltages   map[string]InferredVoltage
+	Unknowns   []UnknownVoltage
+	Inferences []VoltageInference
+}
+
+// VoltageInference is the stable provenance record for a rail voltage decision.
+// Voltage is nil when Architon found rail-like evidence but could not choose a
+// deterministic single value.
+type VoltageInference struct {
+	NetName         string   `json:"net_name"`
+	Voltage         *float64 `json:"voltage"`
+	Source          string   `json:"source"`
+	ConfidenceScore float64  `json:"confidence_score"`
+	ConfidenceLevel string   `json:"confidence_level"`
+	Evidence        []string `json:"evidence"`
+	Warnings        []string `json:"warnings"`
+}
+
+// VoltageEvidence carries non-name evidence into inference, such as explicit
+// metadata overrides or regulator outputs discovered by propagation.
+type VoltageEvidence struct {
+	NetName   string
+	Voltage   float64
+	Source    string
+	BaseScore float64
+	Evidence  string
+}
+
+// VoltageInferenceOptions keeps name parsing deterministic while allowing scan
+// to enrich the result with metadata/regulator evidence and propagation conflicts.
+type VoltageInferenceOptions struct {
+	Evidence  []VoltageEvidence
+	Conflicts []string
 }
 
 func InferVoltagesFromNetNames(design *ir.DesignIR) Result {
+	return InferVoltages(design, VoltageInferenceOptions{})
+}
+
+// InferVoltages produces both the legacy voltage maps used by rules and the
+// richer confidence/provenance records used by reports and --explain-rails.
+func InferVoltages(design *ir.DesignIR, opts VoltageInferenceOptions) Result {
 	result := Result{
 		Voltages: map[string]InferredVoltage{},
 	}
-	if design == nil {
-		return result
-	}
 
-	netNames := make([]string, 0, len(design.Nets))
 	seen := map[string]struct{}{}
-	for _, net := range design.Nets {
-		name := strings.TrimSpace(net.Name)
+	addNetName := func(name string) {
+		name = strings.TrimSpace(name)
 		if name == "" {
-			continue
+			return
 		}
 		if _, ok := seen[name]; ok {
-			continue
+			return
 		}
 		seen[name] = struct{}{}
-		netNames = append(netNames, name)
+	}
+
+	if design != nil {
+		for _, net := range design.Nets {
+			addNetName(net.Name)
+		}
+	}
+
+	for _, evidence := range opts.Evidence {
+		addNetName(evidence.NetName)
+	}
+
+	conflictNets := conflictMessagesByNet(opts.Conflicts)
+	for netName := range conflictNets {
+		addNetName(netName)
+	}
+
+	netNames := make([]string, 0, len(seen))
+	for netName := range seen {
+		netNames = append(netNames, netName)
 	}
 	sort.Strings(netNames)
 
+	states := make(map[string]*inferenceState, len(netNames))
 	for _, netName := range netNames {
-		normalized := normalizeNetName(netName)
-		if voltage, ok := parseExplicitVoltage(normalized); ok {
+		state := newInferenceState(netName)
+		state.addNetNameEvidence()
+		for _, conflict := range conflictNets[netName] {
+			state.hasConflict = true
+			state.addWarning(fmt.Sprintf("conflicting voltage evidence: %s", conflict))
+		}
+		states[netName] = state
+	}
+
+	externalEvidence := append([]VoltageEvidence(nil), opts.Evidence...)
+	sort.Slice(externalEvidence, func(i, j int) bool {
+		if externalEvidence[i].NetName != externalEvidence[j].NetName {
+			return externalEvidence[i].NetName < externalEvidence[j].NetName
+		}
+		if externalEvidence[i].Source != externalEvidence[j].Source {
+			return externalEvidence[i].Source < externalEvidence[j].Source
+		}
+		if externalEvidence[i].Voltage != externalEvidence[j].Voltage {
+			return externalEvidence[i].Voltage < externalEvidence[j].Voltage
+		}
+		return externalEvidence[i].Evidence < externalEvidence[j].Evidence
+	})
+	for _, evidence := range externalEvidence {
+		netName := strings.TrimSpace(evidence.NetName)
+		if netName == "" {
+			continue
+		}
+		state := states[netName]
+		if state == nil {
+			state = newInferenceState(netName)
+			state.addNetNameEvidence()
+			states[netName] = state
+		}
+		state.addExternalEvidence(evidence)
+	}
+
+	for _, netName := range netNames {
+		inference := states[netName].finalize()
+		result.Inferences = append(result.Inferences, inference)
+		if inference.Voltage != nil {
 			result.Voltages[netName] = InferredVoltage{
 				Net:     netName,
-				Voltage: voltage,
-				Source:  netNameSource,
+				Voltage: *inference.Voltage,
+				Source:  inference.Source,
 			}
 			continue
 		}
-		if isAmbiguousPowerNetName(normalized) {
+		if reason, ok := unknownVoltageReason(states[netName], inference); ok {
 			result.Unknowns = append(result.Unknowns, UnknownVoltage{
 				Net:    netName,
-				Reason: ambiguousPowerNetReason,
+				Reason: reason,
 			})
 		}
 	}
 
 	return result
+}
+
+// InferVoltageFromNetName is a small test/helper entry point for scoring a
+// single net name without building a DesignIR.
+func InferVoltageFromNetName(netName string) VoltageInference {
+	result := InferVoltages(&ir.DesignIR{
+		Nets: []ir.Net{{Name: netName}},
+	}, VoltageInferenceOptions{})
+	if len(result.Inferences) == 0 {
+		return newInferenceState(netName).finalize()
+	}
+	return result.Inferences[0]
+}
+
+type voltageCandidate struct {
+	voltage float64
+	source  string
+	score   float64
+}
+
+type inferenceState struct {
+	netName                   string
+	normalized                string
+	candidates                []voltageCandidate
+	evidence                  []string
+	warnings                  []string
+	hasGenericRailName        bool
+	hasHeuristicExtraction    bool
+	hasMultipleVoltageOptions bool
+	hasConflict               bool
+	noVoltageSource           string
+	noVoltageScore            float64
+}
+
+func newInferenceState(netName string) *inferenceState {
+	normalized := normalizeNetName(netName)
+	return &inferenceState{
+		netName:            strings.TrimSpace(netName),
+		normalized:         normalized,
+		hasGenericRailName: hasGenericRailName(normalized),
+		noVoltageSource:    SourceUnknown,
+		noVoltageScore:     scoreUnknown,
+	}
+}
+
+// addNetNameEvidence records deterministic evidence available from the net name
+// alone. Exact forms get high confidence; suffix tokens such as VCC_3V3 are
+// treated as heuristic-only because the surrounding name can change meaning.
+func (s *inferenceState) addNetNameEvidence() {
+	if s.normalized == "" {
+		s.addWarning("net name is empty")
+		return
+	}
+
+	if s.normalized == "GND" {
+		s.addCandidate(0, SourceNetNameExact, scoreNetNameExact)
+		s.addEvidence(fmt.Sprintf("matched ground net %q", s.netName))
+		return
+	}
+
+	if voltage, ok := parseExactVoltage(s.normalized); ok {
+		s.addCandidate(voltage, SourceNetNameExact, scoreNetNameExact)
+		s.addEvidence(fmt.Sprintf("matched exact voltage pattern %q", s.netName))
+		return
+	}
+
+	if voltage, ok := knownSemanticAliases[s.normalized]; ok {
+		s.addCandidate(voltage, SourceSemanticAlias, scoreSemanticAlias)
+		s.addEvidence(fmt.Sprintf("matched known semantic alias %q = %s", s.normalized, formatVoltage(voltage)))
+		return
+	}
+
+	if _, ok := weakSemanticAliases[s.normalized]; ok {
+		s.noVoltageSource = SourceWeakSemanticAlias
+		s.noVoltageScore = scoreWeakSemanticAlias
+		s.addEvidence(fmt.Sprintf("matched weak semantic alias %q", s.normalized))
+		s.addWarning(fmt.Sprintf("weak semantic alias %q does not identify a unique voltage", s.normalized))
+		return
+	}
+
+	voltageTokens := voltageTokens(s.normalized)
+	if len(voltageTokens) > 0 {
+		s.hasHeuristicExtraction = true
+		for _, token := range voltageTokens {
+			voltage, ok := parseVoltageToken(token)
+			if !ok {
+				continue
+			}
+			s.addCandidate(voltage, SourceAmbiguousNumericToken, scoreAmbiguousNumericToken)
+			s.addEvidence(fmt.Sprintf("matched ambiguous voltage token %q in net name %q", token, s.netName))
+		}
+	}
+}
+
+// addExternalEvidence records evidence produced elsewhere in the scan. These
+// sources intentionally outrank weak/heuristic name matches when they disagree.
+func (s *inferenceState) addExternalEvidence(evidence VoltageEvidence) {
+	source := strings.TrimSpace(evidence.Source)
+	if source == "" {
+		source = SourceUnknown
+	}
+	score := evidence.BaseScore
+	if score == 0 && source != SourceUnknown {
+		score = defaultScoreForSource(source)
+	}
+	s.addCandidate(evidence.Voltage, source, score)
+
+	evidenceText := strings.TrimSpace(evidence.Evidence)
+	if evidenceText == "" {
+		evidenceText = fmt.Sprintf("matched %s evidence for %q at %s", source, evidence.NetName, formatVoltage(evidence.Voltage))
+	}
+	s.addEvidence(evidenceText)
+}
+
+func (s *inferenceState) addCandidate(voltage float64, source string, score float64) {
+	s.candidates = append(s.candidates, voltageCandidate{
+		voltage: voltage,
+		source:  source,
+		score:   score,
+	})
+}
+
+func (s *inferenceState) addEvidence(evidence string) {
+	evidence = strings.TrimSpace(evidence)
+	if evidence == "" {
+		return
+	}
+	for _, existing := range s.evidence {
+		if existing == evidence {
+			return
+		}
+	}
+	s.evidence = append(s.evidence, evidence)
+}
+
+func (s *inferenceState) addWarning(warning string) {
+	warning = strings.TrimSpace(warning)
+	if warning == "" {
+		return
+	}
+	for _, existing := range s.warnings {
+		if existing == warning {
+			return
+		}
+	}
+	s.warnings = append(s.warnings, warning)
+}
+
+// finalize applies downgrade rules after all evidence has been gathered. This
+// keeps scoring order-independent and makes conflict handling deterministic.
+func (s *inferenceState) finalize() VoltageInference {
+	source := s.noVoltageSource
+	baseScore := s.noVoltageScore
+	var voltage *float64
+
+	distinctVoltages := distinctCandidateVoltages(s.candidates)
+	if len(s.candidates) > 0 {
+		best, hasBest := bestCandidate(s.candidates)
+		if hasBest {
+			source = best.source
+			baseScore = best.score
+			if len(distinctVoltages) == 1 || hasAuthoritativeSource(best.source) {
+				v := best.voltage
+				voltage = &v
+			}
+		}
+	}
+
+	if len(distinctVoltages) > 1 {
+		s.hasMultipleVoltageOptions = true
+		s.hasConflict = true
+	}
+
+	score := baseScore
+	if shouldApplyGenericDowngrade(s) {
+		score -= 0.20
+		s.addWarning(fmt.Sprintf("generic rail name %q reduces confidence", s.netName))
+	}
+	if s.hasMultipleVoltageOptions {
+		score -= 0.20
+		s.addWarning("multiple candidate voltages detected")
+	}
+	if s.hasHeuristicExtraction {
+		score -= 0.30
+		s.addWarning("heuristic-only voltage extraction used")
+	}
+	if s.hasConflict {
+		score -= 0.50
+		s.addWarning("conflicting voltage evidence detected")
+	}
+
+	if source == "" {
+		source = SourceUnknown
+	}
+	score = normalizeScore(score)
+	if source == SourceUnknown && len(s.evidence) == 0 && len(s.warnings) == 0 {
+		s.addWarning(fmt.Sprintf("no voltage evidence found in net name %q", s.netName))
+	}
+
+	sort.Strings(s.evidence)
+	sort.Strings(s.warnings)
+
+	return VoltageInference{
+		NetName:         s.netName,
+		Voltage:         voltage,
+		Source:          source,
+		ConfidenceScore: score,
+		ConfidenceLevel: confidenceLevel(score),
+		Evidence:        stableStrings(s.evidence),
+		Warnings:        stableStrings(s.warnings),
+	}
 }
 
 func normalizeNetName(netName string) string {
@@ -99,11 +449,7 @@ func isAmbiguousPowerNetName(normalized string) bool {
 	return ok
 }
 
-func parseExplicitVoltage(normalized string) (float64, bool) {
-	if normalized == "GND" {
-		return 0, true
-	}
-
+func parseExactVoltage(normalized string) (float64, bool) {
 	if matches := decimalVoltagePattern.FindStringSubmatch(normalized); len(matches) == 2 {
 		voltage, err := strconv.ParseFloat(matches[1], 64)
 		if err != nil {
@@ -116,13 +462,14 @@ func parseExplicitVoltage(normalized string) (float64, bool) {
 		return voltage, true
 	}
 
-	if matches := suffixVoltagePattern.FindStringSubmatch(normalized); len(matches) == 2 {
-		if voltage, ok := parseExplicitVoltage(matches[1]); ok {
-			return voltage, true
-		}
-	}
-
 	return 0, false
+}
+
+func parseExplicitVoltage(normalized string) (float64, bool) {
+	if normalized == "GND" {
+		return 0, true
+	}
+	return parseExactVoltage(normalized)
 }
 
 func parseVDecimal(value string) (float64, bool) {
@@ -135,4 +482,235 @@ func parseVDecimal(value string) (float64, bool) {
 		return 0, false
 	}
 	return voltage, true
+}
+
+func parseVoltageToken(token string) (float64, bool) {
+	return parseExactVoltage(strings.ToUpper(strings.TrimSpace(token)))
+}
+
+func voltageTokens(normalized string) []string {
+	tokens := splitNetNameTokens(normalized)
+	out := make([]string, 0, len(tokens))
+	seen := map[string]struct{}{}
+	for _, token := range tokens {
+		if _, ok := parseVoltageToken(token); !ok {
+			continue
+		}
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		out = append(out, token)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func splitNetNameTokens(normalized string) []string {
+	fields := strings.FieldsFunc(normalized, func(r rune) bool {
+		return !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '+' || r == '.')
+	})
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+func hasGenericRailName(normalized string) bool {
+	if _, ok := genericRailNameTokens[normalized]; ok {
+		return true
+	}
+	for _, token := range splitNetNameTokens(normalized) {
+		if _, ok := genericRailNameTokens[token]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldApplyGenericDowngrade(s *inferenceState) bool {
+	if !s.hasGenericRailName {
+		return false
+	}
+	// Plain unknown signal names should not be penalized just because a token
+	// happens to match a generic rail word; only rail-like evidence is downgraded.
+	return len(s.candidates) > 0 ||
+		s.noVoltageSource == SourceWeakSemanticAlias ||
+		isAmbiguousPowerNetName(s.normalized)
+}
+
+func distinctCandidateVoltages(candidates []voltageCandidate) []float64 {
+	out := make([]float64, 0, len(candidates))
+	for _, candidate := range candidates {
+		found := false
+		for _, existing := range out {
+			if sameVoltage(existing, candidate.voltage) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, candidate.voltage)
+		}
+	}
+	sort.Float64s(out)
+	return out
+}
+
+func bestCandidate(candidates []voltageCandidate) (voltageCandidate, bool) {
+	if len(candidates) == 0 {
+		return voltageCandidate{}, false
+	}
+	sorted := append([]voltageCandidate(nil), candidates...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].score != sorted[j].score {
+			return sorted[i].score > sorted[j].score
+		}
+		if sourcePriority(sorted[i].source) != sourcePriority(sorted[j].source) {
+			return sourcePriority(sorted[i].source) > sourcePriority(sorted[j].source)
+		}
+		if sorted[i].source != sorted[j].source {
+			return sorted[i].source < sorted[j].source
+		}
+		return sorted[i].voltage < sorted[j].voltage
+	})
+	return sorted[0], true
+}
+
+func hasAuthoritativeSource(source string) bool {
+	// Authoritative sources may still provide a value when weaker evidence
+	// disagrees; the conflict downgrade preserves the reduced confidence.
+	switch source {
+	case SourceUserOverride, SourceNetNameExact, SourceRegulatorOutput, SourceSemanticAlias:
+		return true
+	default:
+		return false
+	}
+}
+
+func sourcePriority(source string) int {
+	switch source {
+	case SourceUserOverride:
+		return 100
+	case SourceNetNameExact:
+		return 90
+	case SourceRegulatorOutput:
+		return 80
+	case SourceSemanticAlias:
+		return 70
+	case SourceWeakSemanticAlias:
+		return 60
+	case SourceAmbiguousNumericToken:
+		return 50
+	default:
+		return 0
+	}
+}
+
+func defaultScoreForSource(source string) float64 {
+	switch source {
+	case SourceUserOverride:
+		return scoreUserOverride
+	case SourceNetNameExact:
+		return scoreNetNameExact
+	case SourceRegulatorOutput:
+		return scoreRegulatorOutput
+	case SourceSemanticAlias:
+		return scoreSemanticAlias
+	case SourceWeakSemanticAlias:
+		return scoreWeakSemanticAlias
+	case SourceAmbiguousNumericToken:
+		return scoreAmbiguousNumericToken
+	default:
+		return scoreUnknown
+	}
+}
+
+func unknownVoltageReason(s *inferenceState, inference VoltageInference) (string, bool) {
+	if inference.Voltage != nil {
+		return "", false
+	}
+	if s.hasMultipleVoltageOptions {
+		return multipleCandidateVoltagesReason, true
+	}
+	if isAmbiguousPowerNetName(s.normalized) || s.noVoltageSource == SourceWeakSemanticAlias {
+		return ambiguousPowerNetReason, true
+	}
+	return "", false
+}
+
+func conflictMessagesByNet(messages []string) map[string][]string {
+	out := map[string][]string{}
+	for _, message := range messages {
+		message = strings.TrimSpace(message)
+		if message == "" {
+			continue
+		}
+		netName := netNameFromConflictMessage(message)
+		if netName == "" {
+			continue
+		}
+		out[netName] = append(out[netName], message)
+	}
+	for netName := range out {
+		sort.Strings(out[netName])
+	}
+	return out
+}
+
+func netNameFromConflictMessage(message string) string {
+	const prefix = "Voltage conflict on net "
+	if !strings.HasPrefix(message, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(message, prefix)
+	idx := strings.Index(rest, ":")
+	if idx < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:idx])
+}
+
+func confidenceLevel(score float64) string {
+	switch {
+	case score >= 0.90:
+		return ConfidenceHigh
+	case score >= 0.70:
+		return ConfidenceMedium
+	case score >= 0.40:
+		return ConfidenceLow
+	default:
+		return ConfidenceUnknown
+	}
+}
+
+func normalizeScore(score float64) float64 {
+	if score < 0 {
+		score = 0
+	}
+	if score > 1 {
+		score = 1
+	}
+	return math.Round(score*100) / 100
+}
+
+func sameVoltage(left float64, right float64) bool {
+	return math.Abs(left-right) < 1e-9
+}
+
+func formatVoltage(voltage float64) string {
+	return fmt.Sprintf("%.2fV", voltage)
+}
+
+func stableStrings(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
 }

--- a/internal/infer/infer_test.go
+++ b/internal/infer/infer_test.go
@@ -1,6 +1,8 @@
 package infer
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/badimirzai/architon-cli/internal/ir"
@@ -10,13 +12,14 @@ func TestInferVoltagesFromNetNames(t *testing.T) {
 	tests := []struct {
 		net     string
 		voltage float64
+		source  string
 	}{
-		{net: "/+5V", voltage: 5.0},
-		{net: "3V3", voltage: 3.3},
-		{net: "/+3.3V", voltage: 3.3},
-		{net: "VBAT_24V", voltage: 24.0},
-		{net: "/+4.24554V", voltage: 4.24554},
-		{net: "GND", voltage: 0.0},
+		{net: "/+5V", voltage: 5.0, source: SourceNetNameExact},
+		{net: "3V3", voltage: 3.3, source: SourceNetNameExact},
+		{net: "/+3.3V", voltage: 3.3, source: SourceNetNameExact},
+		{net: "VBAT_24V", voltage: 24.0, source: SourceAmbiguousNumericToken},
+		{net: "/+4.24554V", voltage: 4.24554, source: SourceNetNameExact},
+		{net: "GND", voltage: 0.0, source: SourceNetNameExact},
 	}
 
 	for _, tt := range tests {
@@ -32,8 +35,8 @@ func TestInferVoltagesFromNetNames(t *testing.T) {
 			if got.Voltage != tt.voltage {
 				t.Fatalf("expected %v, got %v", tt.voltage, got.Voltage)
 			}
-			if got.Source != "net_name" {
-				t.Fatalf("expected source net_name, got %q", got.Source)
+			if got.Source != tt.source {
+				t.Fatalf("expected source %s, got %q", tt.source, got.Source)
 			}
 			if len(result.Unknowns) != 0 {
 				t.Fatalf("expected no unknowns, got %+v", result.Unknowns)
@@ -63,8 +66,8 @@ func TestInferVoltagesFromNetNames_ReportsAmbiguousPowerNets(t *testing.T) {
 		if result.Unknowns[i].Net != net {
 			t.Fatalf("expected unknown %d net %q, got %q", i, net, result.Unknowns[i].Net)
 		}
-		if result.Unknowns[i].Reason != "ambiguous power net name" {
-			t.Fatalf("expected ambiguous reason, got %q", result.Unknowns[i].Reason)
+		if result.Unknowns[i].Reason == "" {
+			t.Fatalf("expected unknown reason")
 		}
 	}
 }
@@ -74,7 +77,6 @@ func TestInferVoltagesFromNetNames_DoesNotInferUnlistedNames(t *testing.T) {
 		Nets: []ir.Net{
 			{Name: "SCL"},
 			{Name: "POWER_GOOD"},
-			{Name: "+5V_USB"},
 		},
 	})
 
@@ -84,4 +86,241 @@ func TestInferVoltagesFromNetNames_DoesNotInferUnlistedNames(t *testing.T) {
 	if len(result.Unknowns) != 0 {
 		t.Fatalf("expected no unknown voltage nets, got %+v", result.Unknowns)
 	}
+}
+
+func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
+	tests := []struct {
+		name     string
+		net      string
+		voltage  *float64
+		source   string
+		score    float64
+		level    string
+		evidence string
+		warning  string
+	}{
+		{
+			name:     "slash plus 5V",
+			net:      "/+5V",
+			voltage:  ptr(5.0),
+			source:   SourceNetNameExact,
+			score:    0.95,
+			level:    ConfidenceHigh,
+			evidence: `matched exact voltage pattern "/+5V"`,
+		},
+		{
+			name:     "plus 5V",
+			net:      "+5V",
+			voltage:  ptr(5.0),
+			source:   SourceNetNameExact,
+			score:    0.95,
+			level:    ConfidenceHigh,
+			evidence: `matched exact voltage pattern "+5V"`,
+		},
+		{
+			name:     "bare 5V",
+			net:      "5V",
+			voltage:  ptr(5.0),
+			source:   SourceNetNameExact,
+			score:    0.95,
+			level:    ConfidenceHigh,
+			evidence: `matched exact voltage pattern "5V"`,
+		},
+		{
+			name:     "slash 3V3",
+			net:      "/3V3",
+			voltage:  ptr(3.3),
+			source:   SourceNetNameExact,
+			score:    0.95,
+			level:    ConfidenceHigh,
+			evidence: `matched exact voltage pattern "/3V3"`,
+		},
+		{
+			name:     "VCC 3V3",
+			net:      "VCC_3V3",
+			voltage:  ptr(3.3),
+			source:   SourceAmbiguousNumericToken,
+			score:    0.00,
+			level:    ConfidenceUnknown,
+			evidence: `matched ambiguous voltage token "3V3" in net name "VCC_3V3"`,
+			warning:  "heuristic-only voltage extraction used",
+		},
+		{
+			name:     "VBUS",
+			net:      "VBUS",
+			voltage:  ptr(5.0),
+			source:   SourceSemanticAlias,
+			score:    0.80,
+			level:    ConfidenceMedium,
+			evidence: `matched known semantic alias "VBUS" = 5.00V`,
+		},
+		{
+			name:    "VIN",
+			net:     "VIN",
+			source:  SourceUnknown,
+			score:   0.00,
+			level:   ConfidenceUnknown,
+			warning: `generic rail name "VIN" reduces confidence`,
+		},
+		{
+			name:     "VDD",
+			net:      "VDD",
+			source:   SourceWeakSemanticAlias,
+			score:    0.45,
+			level:    ConfidenceLow,
+			evidence: `matched weak semantic alias "VDD"`,
+			warning:  `weak semantic alias "VDD" does not identify a unique voltage`,
+		},
+		{
+			name:     "SUPPLY 4V7",
+			net:      "SUPPLY_4V7",
+			voltage:  ptr(4.7),
+			source:   SourceAmbiguousNumericToken,
+			score:    0.00,
+			level:    ConfidenceUnknown,
+			evidence: `matched ambiguous voltage token "4V7" in net name "SUPPLY_4V7"`,
+			warning:  `generic rail name "SUPPLY_4V7" reduces confidence`,
+		},
+		{
+			name:    "multiple candidates",
+			net:     "RAIL_3V3_5V",
+			source:  SourceAmbiguousNumericToken,
+			score:   0.00,
+			level:   ConfidenceUnknown,
+			warning: "multiple candidate voltages detected",
+		},
+		{
+			name:    "unknown",
+			net:     "SCL",
+			source:  SourceUnknown,
+			score:   0.00,
+			level:   ConfidenceUnknown,
+			warning: `no voltage evidence found in net name "SCL"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InferVoltageFromNetName(tt.net)
+			assertVoltageInference(t, got, tt.net, tt.voltage, tt.source, tt.score, tt.level)
+			if tt.evidence != "" && !containsString(got.Evidence, tt.evidence) {
+				t.Fatalf("expected evidence %q, got %+v", tt.evidence, got.Evidence)
+			}
+			if tt.warning != "" && !containsString(got.Warnings, tt.warning) {
+				t.Fatalf("expected warning %q, got %+v", tt.warning, got.Warnings)
+			}
+		})
+	}
+}
+
+func TestInferVoltageFromNetName_ExactNumericExamples(t *testing.T) {
+	tests := map[string]float64{
+		"12V": 12.0,
+		"1V8": 1.8,
+	}
+	for net, voltage := range tests {
+		got := InferVoltageFromNetName(net)
+		assertVoltageInference(t, got, net, ptr(voltage), SourceNetNameExact, 0.95, ConfidenceHigh)
+	}
+}
+
+func TestInferVoltages_ExternalEvidenceScores(t *testing.T) {
+	result := InferVoltages(&ir.DesignIR{
+		Nets: []ir.Net{
+			{Name: "/+5V"},
+			{Name: "VBAT"},
+			{Name: "REG_OUT"},
+		},
+	}, VoltageInferenceOptions{
+		Evidence: []VoltageEvidence{
+			{
+				NetName:  "VBAT",
+				Voltage:  24.0,
+				Source:   SourceUserOverride,
+				Evidence: `user override set rail "VBAT" to 24.00V`,
+			},
+			{
+				NetName:  "REG_OUT",
+				Voltage:  3.3,
+				Source:   SourceRegulatorOutput,
+				Evidence: `regulator U1 output mapped to rail "REG_OUT" at 3.30V`,
+			},
+		},
+	})
+
+	assertVoltageInference(t, findInference(t, result, "VBAT"), "VBAT", ptr(24.0), SourceUserOverride, 1.00, ConfidenceHigh)
+	assertVoltageInference(t, findInference(t, result, "REG_OUT"), "REG_OUT", ptr(3.3), SourceRegulatorOutput, 0.90, ConfidenceHigh)
+}
+
+func TestInferVoltages_ConflictingEvidenceDowngrades(t *testing.T) {
+	result := InferVoltages(&ir.DesignIR{
+		Nets: []ir.Net{{Name: "/+5V"}},
+	}, VoltageInferenceOptions{
+		Evidence: []VoltageEvidence{
+			{
+				NetName:  "/+5V",
+				Voltage:  4.7,
+				Source:   SourceUserOverride,
+				Evidence: `user override set rail "/+5V" to 4.70V`,
+			},
+		},
+	})
+
+	got := findInference(t, result, "/+5V")
+	assertVoltageInference(t, got, "/+5V", ptr(4.7), SourceUserOverride, 0.30, ConfidenceUnknown)
+	if !containsString(got.Warnings, "conflicting voltage evidence detected") {
+		t.Fatalf("expected conflicting evidence warning, got %+v", got.Warnings)
+	}
+}
+
+func ptr(v float64) *float64 {
+	return &v
+}
+
+func assertVoltageInference(t *testing.T, got VoltageInference, net string, voltage *float64, source string, score float64, level string) {
+	t.Helper()
+	if got.NetName != net {
+		t.Fatalf("expected net %q, got %q", net, got.NetName)
+	}
+	if voltage == nil {
+		if got.Voltage != nil {
+			t.Fatalf("expected nil voltage, got %v", *got.Voltage)
+		}
+	} else {
+		if got.Voltage == nil {
+			t.Fatalf("expected voltage %v, got nil", *voltage)
+		}
+		if math.Abs(*got.Voltage-*voltage) > 1e-9 {
+			t.Fatalf("expected voltage %v, got %v", *voltage, *got.Voltage)
+		}
+	}
+	if got.Source != source {
+		t.Fatalf("expected source %s, got %s", source, got.Source)
+	}
+	if math.Abs(got.ConfidenceScore-score) > 1e-9 {
+		t.Fatalf("expected score %.2f, got %.2f", score, got.ConfidenceScore)
+	}
+	if got.ConfidenceLevel != level {
+		t.Fatalf("expected level %s, got %s", level, got.ConfidenceLevel)
+	}
+}
+
+func findInference(t *testing.T, result Result, net string) VoltageInference {
+	t.Helper()
+	for _, inference := range result.Inferences {
+		if inference.NetName == net {
+			return inference
+		}
+	}
+	t.Fatalf("expected inference for %q, got %+v", net, result.Inferences)
+	return VoltageInference{}
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/rails/coverage.go
+++ b/internal/rails/coverage.go
@@ -1,0 +1,253 @@
+package rails
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/badimirzai/architon-cli/internal/infer"
+	"github.com/badimirzai/architon-cli/internal/ir"
+)
+
+const (
+	OverallHigh    = "HIGH"
+	OverallMedium  = "MEDIUM"
+	OverallLow     = "LOW"
+	OverallUnknown = "UNKNOWN"
+)
+
+const (
+	WarningLowConfidence       = "some rails have low-confidence voltage inference"
+	WarningUnknownVoltage      = "some rails have unknown voltage and cannot be checked by voltage rules"
+	WarningIncompleteCoverage  = "rail voltage coverage is incomplete; voltage checks may miss issues"
+	WarningConflictingEvidence = "some rails have conflicting voltage evidence"
+)
+
+type RailCoverageSummary struct {
+	TotalNets           int      `json:"total_nets"`
+	RailsWithVoltage    int      `json:"rails_with_voltage"`
+	RailsUnknown        int      `json:"rails_unknown"`
+	HighConfidence      int      `json:"high_confidence"`
+	MediumConfidence    int      `json:"medium_confidence"`
+	LowConfidence       int      `json:"low_confidence"`
+	UnknownConfidence   int      `json:"unknown_confidence"`
+	CoverageRatio       float64  `json:"coverage_ratio"`
+	HighConfidenceRatio float64  `json:"high_confidence_ratio"`
+	UsableForRulesRatio float64  `json:"usable_for_rules_ratio"`
+	OverallLevel        string   `json:"overall_level"`
+	Warnings            []string `json:"warnings"`
+}
+
+func SummarizeRailCoverage(design *ir.DesignIR, inferences []infer.VoltageInference) RailCoverageSummary {
+	totalNets := 0
+	netNames := make([]string, 0)
+	if design != nil {
+		totalNets = len(design.Nets)
+		netNames = make([]string, 0, len(design.Nets))
+		for _, net := range design.Nets {
+			netNames = append(netNames, strings.TrimSpace(net.Name))
+		}
+	}
+
+	byNet := make(map[string]infer.VoltageInference, len(inferences))
+	for _, inference := range inferences {
+		netName := strings.TrimSpace(inference.NetName)
+		if netName == "" {
+			continue
+		}
+		byNet[netName] = inference
+	}
+
+	summary := RailCoverageSummary{
+		TotalNets:    totalNets,
+		OverallLevel: OverallUnknown,
+		Warnings:     []string{},
+	}
+
+	hasLowConfidenceInference := false
+	hasConflictingEvidence := false
+	usableForRules := 0
+
+	for _, netName := range netNames {
+		inference, ok := byNet[netName]
+		if !ok {
+			summary.RailsUnknown++
+			summary.UnknownConfidence++
+			continue
+		}
+
+		if inference.Voltage == nil {
+			summary.RailsUnknown++
+		} else {
+			summary.RailsWithVoltage++
+		}
+
+		switch strings.ToUpper(strings.TrimSpace(inference.ConfidenceLevel)) {
+		case infer.ConfidenceHigh:
+			summary.HighConfidence++
+			if inference.Voltage != nil {
+				usableForRules++
+			}
+		case infer.ConfidenceMedium:
+			summary.MediumConfidence++
+			if inference.Voltage != nil {
+				usableForRules++
+			}
+		case infer.ConfidenceLow:
+			summary.LowConfidence++
+			hasLowConfidenceInference = true
+		default:
+			summary.UnknownConfidence++
+		}
+
+		if hasConflictWarning(inference.Warnings) {
+			hasConflictingEvidence = true
+		}
+	}
+
+	if totalNets > 0 {
+		summary.CoverageRatio = ratio(summary.RailsWithVoltage, totalNets)
+		summary.HighConfidenceRatio = ratio(summary.HighConfidence, totalNets)
+		summary.UsableForRulesRatio = ratio(usableForRules, totalNets)
+		summary.OverallLevel = overallLevel(summary.UsableForRulesRatio)
+	}
+
+	if hasLowConfidenceInference {
+		summary.Warnings = append(summary.Warnings, WarningLowConfidence)
+	}
+	if summary.RailsUnknown > 0 {
+		summary.Warnings = append(summary.Warnings, WarningUnknownVoltage)
+	}
+	if totalNets > 0 && summary.UsableForRulesRatio < 0.70 {
+		summary.Warnings = append(summary.Warnings, WarningIncompleteCoverage)
+	}
+	if hasConflictingEvidence {
+		summary.Warnings = append(summary.Warnings, WarningConflictingEvidence)
+	}
+
+	return summary
+}
+
+func FormatRailCoverage(summary RailCoverageSummary) string {
+	return fmt.Sprintf("%s %s", normalizeOverallLevel(summary.OverallLevel), formatPercent(summary.UsableForRulesRatio))
+}
+
+func FormatRailExplanations(inferences []infer.VoltageInference, summary RailCoverageSummary) string {
+	var b strings.Builder
+
+	sorted := append([]infer.VoltageInference(nil), inferences...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].NetName != sorted[j].NetName {
+			return sorted[i].NetName < sorted[j].NetName
+		}
+		return sorted[i].Source < sorted[j].Source
+	})
+
+	b.WriteString("Rail inference:\n")
+	for _, inference := range sorted {
+		voltage := "UNKNOWN"
+		if inference.Voltage != nil {
+			voltage = fmt.Sprintf("%.2fV", *inference.Voltage)
+		}
+		b.WriteString(fmt.Sprintf("- %s%s%-6s %-6s %-4.2f  %s\n",
+			formatRailNetLabel(inference.NetName),
+			railNetLabelSpacing(inference.NetName),
+			voltage,
+			normalizeConfidenceLevel(inference.ConfidenceLevel),
+			inference.ConfidenceScore,
+			inference.Source,
+		))
+		for _, warning := range stableWarningLines(inference.Warnings) {
+			b.WriteString(fmt.Sprintf("  warning: %s\n", warning))
+		}
+	}
+
+	usableForRules := int(math.Round(summary.UsableForRulesRatio * float64(summary.TotalNets)))
+	b.WriteString("\n")
+	b.WriteString("Rail coverage:\n")
+	b.WriteString(fmt.Sprintf("- Total nets: %d\n", summary.TotalNets))
+	b.WriteString(fmt.Sprintf("- Usable for rules: %d/%d\n", usableForRules, summary.TotalNets))
+	b.WriteString(fmt.Sprintf("- Coverage: %s\n", FormatRailCoverage(summary)))
+
+	return b.String()
+}
+
+func formatRailNetLabel(netName string) string {
+	return strings.TrimSpace(netName) + ":"
+}
+
+func railNetLabelSpacing(netName string) string {
+	labelWidth := len(formatRailNetLabel(netName))
+	spaces := 1
+	if labelWidth <= 4 {
+		spaces = 3
+	}
+	return strings.Repeat(" ", spaces)
+}
+
+func ratio(count int, total int) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return math.Round((float64(count)/float64(total))*10000) / 10000
+}
+
+func stableWarningLines(warnings []string) []string {
+	out := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		warning = strings.TrimSpace(warning)
+		if warning == "" {
+			continue
+		}
+		out = append(out, warning)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func overallLevel(usableForRulesRatio float64) string {
+	switch {
+	case usableForRulesRatio >= 0.90:
+		return OverallHigh
+	case usableForRulesRatio >= 0.70:
+		return OverallMedium
+	case usableForRulesRatio >= 0.40:
+		return OverallLow
+	default:
+		return OverallUnknown
+	}
+}
+
+func formatPercent(value float64) string {
+	return fmt.Sprintf("%.0f%%", math.Round(value*100))
+}
+
+func normalizeOverallLevel(level string) string {
+	level = strings.ToUpper(strings.TrimSpace(level))
+	switch level {
+	case OverallHigh, OverallMedium, OverallLow:
+		return level
+	default:
+		return OverallUnknown
+	}
+}
+
+func normalizeConfidenceLevel(level string) string {
+	level = strings.ToUpper(strings.TrimSpace(level))
+	switch level {
+	case infer.ConfidenceHigh, infer.ConfidenceMedium, infer.ConfidenceLow:
+		return level
+	default:
+		return infer.ConfidenceUnknown
+	}
+}
+
+func hasConflictWarning(warnings []string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(strings.ToLower(warning), "conflicting voltage evidence") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rails/coverage_test.go
+++ b/internal/rails/coverage_test.go
@@ -1,0 +1,213 @@
+package rails
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/badimirzai/architon-cli/internal/infer"
+	"github.com/badimirzai/architon-cli/internal/ir"
+)
+
+func TestSummarizeRailCoverage_AllHighIsOverallHigh(t *testing.T) {
+	summary := SummarizeRailCoverage(designWithNets("GND", "/+5V"), []infer.VoltageInference{
+		inference("GND", ptr(0), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+		inference("/+5V", ptr(5), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+	})
+
+	if summary.OverallLevel != OverallHigh {
+		t.Fatalf("expected overall HIGH, got %s", summary.OverallLevel)
+	}
+	if summary.UsableForRulesRatio != 1 {
+		t.Fatalf("expected usable ratio 1, got %v", summary.UsableForRulesRatio)
+	}
+	if len(summary.Warnings) != 0 {
+		t.Fatalf("expected no warnings, got %+v", summary.Warnings)
+	}
+}
+
+func TestSummarizeRailCoverage_MixedHighMediumUsableRatio(t *testing.T) {
+	summary := SummarizeRailCoverage(designWithNets("/+5V", "VBUS", "VDD"), []infer.VoltageInference{
+		inference("/+5V", ptr(5), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+		inference("VBUS", ptr(5), infer.SourceSemanticAlias, 0.80, infer.ConfidenceMedium),
+		inference("VDD", nil, infer.SourceWeakSemanticAlias, 0.45, infer.ConfidenceLow),
+	})
+
+	if summary.UsableForRulesRatio != 0.6667 {
+		t.Fatalf("expected usable ratio 0.6667, got %v", summary.UsableForRulesRatio)
+	}
+	if summary.HighConfidence != 1 || summary.MediumConfidence != 1 || summary.LowConfidence != 1 {
+		t.Fatalf("unexpected confidence counts: %+v", summary)
+	}
+	if summary.OverallLevel != OverallLow {
+		t.Fatalf("expected overall LOW, got %s", summary.OverallLevel)
+	}
+}
+
+func TestSummarizeRailCoverage_LowConfidenceVoltageWarns(t *testing.T) {
+	summary := SummarizeRailCoverage(designWithNets("AUX_5V"), []infer.VoltageInference{
+		inference("AUX_5V", ptr(5), infer.SourceAmbiguousNumericToken, 0.40, infer.ConfidenceLow),
+	})
+
+	if !contains(summary.Warnings, WarningLowConfidence) {
+		t.Fatalf("expected low confidence warning, got %+v", summary.Warnings)
+	}
+}
+
+func TestSummarizeRailCoverage_UnknownVoltageWarns(t *testing.T) {
+	summary := SummarizeRailCoverage(designWithNets("VIN"), []infer.VoltageInference{
+		inference("VIN", nil, infer.SourceUnknown, 0, infer.ConfidenceUnknown),
+	})
+
+	if summary.RailsUnknown != 1 {
+		t.Fatalf("expected one unknown rail, got %+v", summary)
+	}
+	if !contains(summary.Warnings, WarningUnknownVoltage) {
+		t.Fatalf("expected unknown voltage warning, got %+v", summary.Warnings)
+	}
+}
+
+func TestSummarizeRailCoverage_ZeroNetsDoesNotDivideByZero(t *testing.T) {
+	summary := SummarizeRailCoverage(&ir.DesignIR{}, nil)
+
+	if summary.TotalNets != 0 {
+		t.Fatalf("expected zero total nets, got %d", summary.TotalNets)
+	}
+	if summary.CoverageRatio != 0 || summary.HighConfidenceRatio != 0 || summary.UsableForRulesRatio != 0 {
+		t.Fatalf("expected zero ratios, got %+v", summary)
+	}
+	if summary.OverallLevel != OverallUnknown {
+		t.Fatalf("expected UNKNOWN, got %s", summary.OverallLevel)
+	}
+}
+
+func TestSummarizeRailCoverage_RatiosAreDeterministic(t *testing.T) {
+	summary := SummarizeRailCoverage(designWithNets("/+5V", "VBUS", "VIN"), []infer.VoltageInference{
+		inference("VIN", nil, infer.SourceUnknown, 0, infer.ConfidenceUnknown),
+		inference("VBUS", ptr(5), infer.SourceSemanticAlias, 0.80, infer.ConfidenceMedium),
+		inference("/+5V", ptr(5), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+	})
+
+	if summary.CoverageRatio != 0.6667 {
+		t.Fatalf("expected coverage ratio 0.6667, got %v", summary.CoverageRatio)
+	}
+	if summary.HighConfidenceRatio != 0.3333 {
+		t.Fatalf("expected high confidence ratio 0.3333, got %v", summary.HighConfidenceRatio)
+	}
+	if summary.UsableForRulesRatio != 0.6667 {
+		t.Fatalf("expected usable ratio 0.6667, got %v", summary.UsableForRulesRatio)
+	}
+}
+
+func TestSummarizeRailCoverage_ConflictWarning(t *testing.T) {
+	inf := inference("/+5V", ptr(4.7), infer.SourceUserOverride, 0.30, infer.ConfidenceUnknown)
+	inf.Warnings = []string{"conflicting voltage evidence detected"}
+
+	summary := SummarizeRailCoverage(designWithNets("/+5V"), []infer.VoltageInference{inf})
+
+	if !contains(summary.Warnings, WarningConflictingEvidence) {
+		t.Fatalf("expected conflict warning, got %+v", summary.Warnings)
+	}
+}
+
+func TestFormatRailExplanations_StableSnapshot(t *testing.T) {
+	got := FormatRailExplanations([]infer.VoltageInference{
+		inference("GND", ptr(0), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+		inference("/VBAT", ptr(24), infer.SourceUserOverride, 1.00, infer.ConfidenceHigh),
+		inference("/+5V", ptr(5), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+	}, RailCoverageSummary{
+		TotalNets:           3,
+		UsableForRulesRatio: 1,
+		OverallLevel:        OverallHigh,
+	})
+
+	want := `Rail inference:
+- /+5V: 5.00V  HIGH   0.95  NET_NAME_EXACT
+- /VBAT: 24.00V HIGH   1.00  USER_OVERRIDE
+- GND:   0.00V  HIGH   0.95  NET_NAME_EXACT
+
+Rail coverage:
+- Total nets: 3
+- Usable for rules: 3/3
+- Coverage: HIGH 100%
+`
+	if got != want {
+		t.Fatalf("unexpected rail explanation:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatRailExplanations_UnknownVoltageAndWarnings(t *testing.T) {
+	vin := inference("VIN", nil, "HEURISTIC", 0.35, infer.ConfidenceLow)
+	vin.Warnings = []string{
+		"weak semantic alias does not identify a unique voltage",
+		"generic rail name reduces confidence",
+	}
+
+	got := FormatRailExplanations([]infer.VoltageInference{vin}, RailCoverageSummary{
+		TotalNets:           1,
+		UsableForRulesRatio: 0,
+		OverallLevel:        OverallUnknown,
+	})
+
+	if !strings.Contains(got, "- VIN:   UNKNOWN LOW    0.35  HEURISTIC\n") {
+		t.Fatalf("expected unknown voltage rail line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "  warning: generic rail name reduces confidence\n") {
+		t.Fatalf("expected generic rail warning, got:\n%s", got)
+	}
+	if !strings.Contains(got, "  warning: weak semantic alias does not identify a unique voltage\n") {
+		t.Fatalf("expected weak alias warning, got:\n%s", got)
+	}
+	if strings.Index(got, "generic rail name") > strings.Index(got, "weak semantic alias") {
+		t.Fatalf("expected warning lines to be sorted, got:\n%s", got)
+	}
+}
+
+func TestFormatRailExplanations_CoveragePercentRounding(t *testing.T) {
+	got := FormatRailExplanations([]infer.VoltageInference{
+		inference("/+5V", ptr(5), infer.SourceNetNameExact, 0.95, infer.ConfidenceHigh),
+	}, RailCoverageSummary{
+		TotalNets:           3,
+		UsableForRulesRatio: 0.6667,
+		OverallLevel:        OverallMedium,
+	})
+
+	if !strings.Contains(got, "- Usable for rules: 2/3\n") {
+		t.Fatalf("expected rounded usable count, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- Coverage: MEDIUM 67%\n") {
+		t.Fatalf("expected rounded coverage percent, got:\n%s", got)
+	}
+}
+
+func designWithNets(names ...string) *ir.DesignIR {
+	nets := make([]ir.Net, 0, len(names))
+	for _, name := range names {
+		nets = append(nets, ir.Net{Name: name})
+	}
+	return &ir.DesignIR{Nets: nets}
+}
+
+func inference(net string, voltage *float64, source string, score float64, level string) infer.VoltageInference {
+	return infer.VoltageInference{
+		NetName:         net,
+		Voltage:         voltage,
+		Source:          source,
+		ConfidenceScore: score,
+		ConfidenceLevel: level,
+		Evidence:        []string{},
+		Warnings:        []string{},
+	}
+}
+
+func ptr(value float64) *float64 {
+	return &value
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/badimirzai/architon-cli/internal/infer"
 	"github.com/badimirzai/architon-cli/internal/ir"
 )
 
@@ -46,7 +47,9 @@ type Derived struct {
 	NetVoltages         []NetVoltage        `json:"net_voltages,omitempty"`
 	InferredNetVoltages []NetVoltage        `json:"inferred_net_voltages"`
 	UnknownVoltageNets  []UnknownVoltageNet `json:"unknown_voltage_nets"`
-	Conflicts           []string            `json:"conflicts,omitempty"`
+	// RailInferences records deterministic voltage provenance and confidence for rails.
+	RailInferences []infer.VoltageInference `json:"rail_inferences"`
+	Conflicts      []string                 `json:"conflicts,omitempty"`
 }
 
 type NetVoltage struct {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -8,15 +8,24 @@ import (
 
 	"github.com/badimirzai/architon-cli/internal/infer"
 	"github.com/badimirzai/architon-cli/internal/ir"
+	"github.com/badimirzai/architon-cli/internal/rails"
 )
 
 const SchemaVersion = "0"
 
 // RuleResult is reserved for deterministic verification rules over DesignIR.
 type RuleResult struct {
-	ID       string `json:"id"`
-	Severity string `json:"severity"`
-	Message  string `json:"message"`
+	ID        string               `json:"id"`
+	Severity  string               `json:"severity"`
+	Message   string               `json:"message"`
+	Inference *InferenceProvenance `json:"inference,omitempty"`
+}
+
+type InferenceProvenance struct {
+	NetName         string  `json:"net_name"`
+	Source          string  `json:"source"`
+	ConfidenceScore float64 `json:"confidence_score"`
+	ConfidenceLevel string  `json:"confidence_level"`
 }
 
 type Summary struct {
@@ -48,8 +57,9 @@ type Derived struct {
 	InferredNetVoltages []NetVoltage        `json:"inferred_net_voltages"`
 	UnknownVoltageNets  []UnknownVoltageNet `json:"unknown_voltage_nets"`
 	// RailInferences records deterministic voltage provenance and confidence for rails.
-	RailInferences []infer.VoltageInference `json:"rail_inferences"`
-	Conflicts      []string                 `json:"conflicts,omitempty"`
+	RailInferences []infer.VoltageInference  `json:"rail_inferences"`
+	RailCoverage   rails.RailCoverageSummary `json:"rail_coverage"`
+	Conflicts      []string                  `json:"conflicts,omitempty"`
 }
 
 type NetVoltage struct {

--- a/internal/rules/overvoltage.go
+++ b/internal/rules/overvoltage.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 
+	"github.com/badimirzai/architon-cli/internal/infer"
 	"github.com/badimirzai/architon-cli/internal/ir"
 	"github.com/badimirzai/architon-cli/internal/meta"
 	"github.com/badimirzai/architon-cli/internal/propagate"
@@ -16,6 +17,15 @@ func Overvoltage(
 	desin *ir.DesignIR,
 	meta *meta.Meta,
 	netVoltages map[string]propagate.NetVoltage, // The results from the Propagate function
+) []report.RuleResult {
+	return OvervoltageWithInferences(desin, meta, netVoltages, nil)
+}
+
+func OvervoltageWithInferences(
+	desin *ir.DesignIR,
+	meta *meta.Meta,
+	netVoltages map[string]propagate.NetVoltage,
+	inferencesByNet map[string]infer.VoltageInference,
 ) []report.RuleResult {
 	var results []report.RuleResult
 
@@ -35,9 +45,7 @@ func Overvoltage(
 
 			// Step 4: Compare the actual net voltage against the component's safety limit.
 			if netV.Voltage > comp.MaxVoltage {
-
-				// Step 5: If it's too high, record a rule violation.
-				results = append(results, report.RuleResult{
+				result := report.RuleResult{
 					ID:       "RULE_OVERVOLTAGE",
 					Severity: "error", // critical failure that could damage hardware.
 					Message: fmt.Sprintf(
@@ -48,7 +56,18 @@ func Overvoltage(
 						netV.Voltage,
 						comp.MaxVoltage,
 					),
-				})
+				}
+				if inference, ok := inferencesByNet[c.Net]; ok {
+					result.Inference = &report.InferenceProvenance{
+						NetName:         inference.NetName,
+						Source:          inference.Source,
+						ConfidenceScore: inference.ConfidenceScore,
+						ConfidenceLevel: inference.ConfidenceLevel,
+					}
+				}
+
+				// Step 5: If it's too high, record a rule violation.
+				results = append(results, result)
 			}
 		}
 	}

--- a/internal/rules/overvoltage_test.go
+++ b/internal/rules/overvoltage_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"testing"
 
+	"github.com/badimirzai/architon-cli/internal/infer"
 	"github.com/badimirzai/architon-cli/internal/ir"
 	"github.com/badimirzai/architon-cli/internal/meta"
 	"github.com/badimirzai/architon-cli/internal/propagate"
@@ -31,6 +32,47 @@ func TestOvervoltage_Triggers(t *testing.T) {
 	}
 	if got[0].ID != "RULE_OVERVOLTAGE" {
 		t.Fatalf("expected RULE_OVERVOLTAGE, got %s", got[0].ID)
+	}
+}
+
+func TestOvervoltage_IncludesInferenceProvenance(t *testing.T) {
+	design := &ir.DesignIR{
+		Nets: []ir.Net{
+			{Name: "/+5V", Pins: []ir.PinRef{{Ref: "U1", Pin: "1"}}},
+		},
+	}
+	m := &meta.Meta{
+		Components: []meta.Component{
+			{Ref: "U1", MaxVoltage: 3.3},
+		},
+	}
+	netV := map[string]propagate.NetVoltage{
+		"/+5V": {Net: "/+5V", Voltage: 5.0, Source: "initial"},
+	}
+	inferences := map[string]infer.VoltageInference{
+		"/+5V": {
+			NetName:         "/+5V",
+			Source:          infer.SourceNetNameExact,
+			ConfidenceScore: 0.95,
+			ConfidenceLevel: infer.ConfidenceHigh,
+		},
+	}
+
+	got := OvervoltageWithInferences(design, m, netV, inferences)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(got))
+	}
+	if got[0].Inference == nil {
+		t.Fatalf("expected inference provenance, got %+v", got[0])
+	}
+	if got[0].Inference.NetName != "/+5V" {
+		t.Fatalf("expected net /+5V, got %+v", got[0].Inference)
+	}
+	if got[0].Inference.Source != infer.SourceNetNameExact {
+		t.Fatalf("expected source %s, got %+v", infer.SourceNetNameExact, got[0].Inference)
+	}
+	if got[0].Inference.ConfidenceLevel != infer.ConfidenceHigh || got[0].Inference.ConfidenceScore != 0.95 {
+		t.Fatalf("expected high confidence provenance, got %+v", got[0].Inference)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add rail coverage summary metrics under `derived.rail_coverage`
- Show compact rail coverage in `rv scan` terminal output
- Add detailed `--explain-rails` / `--rails` rail inference table
- Attach inference provenance to voltage-based findings when available
- Preserve existing scan exit-code behavior and JSON compatibility
- Update docs and cheatsheet for current scan flags, exit codes, and report fields

## Verification
- `go test ./...`
- Manual `rv scan ... --meta ... --rails` check
