### PR TITLE
Feat/ Make rv scan . work directly on KiCad schematic projects without committed netlists

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -17,9 +17,12 @@ rv scan <bom.csv> --out report.json    Write scan report to a specific path
 rv scan <netlist.net> --meta .architon/meta.yaml
                                       Enable metadata-backed voltage rules
 rv scan <netlist.net> --rails          Show rail inference details
-rv scan .                              Auto-detect BOM and/or netlist in current directory
+rv scan .                              Auto-detect BOM/netlist, or export netlist from root schematic
 rv scan . --bom bom/bom.csv --netlist exports/project.net
                                       Override detected project files
+rv scan . --kicad-cli /full/path/to/kicad-cli
+                                      Use an explicit KiCad CLI binary
+rv doctor                             Check rv and KiCad CLI setup
 rv init                                Create .architon/meta.yaml and README.md
 rv init --list                        List available templates
 rv init --template <name>             Write a template to robot.yaml
@@ -53,6 +56,8 @@ rv scan --help                         Show scan command options
 --meta <file.yaml>        metadata for sources, regulators, and component limits
 --rails                   print rail voltage inference and confidence details
 --explain-rails           legacy alias for --rails
+--no-kicad-cli            disable automatic schematic netlist generation
+--kicad-cli <path>        override KiCad CLI binary name/path
 --out <report.json>       write scan report to a specific path
 ```
 
@@ -70,6 +75,7 @@ NO_COLOR=1 rv check examples/minimal_voltage_mismatch.yaml
 rv scan bom.csv
 rv scan exports/example.net
 rv scan .
+rv scan . --kicad-cli /full/path/to/kicad-cli
 rv scan . --bom bom/bom.csv --netlist exports/project.net
 rv scan bom.csv --map examples/mapping.yaml
 rv scan bom.csv --out my-report.json
@@ -95,13 +101,15 @@ Directory scan detection order:
 
 - BOM: `bom/bom.csv`, `bom.csv`, `exports/bom.csv`, then lexical `*bom*.csv`
 - Netlist: lexical `exports/*.net`, then lexical `*.net` in project root
+- Schematic fallback: if no `.net` exists, one root `*.kicad_sch` can be exported through KiCad CLI
 
 Successful `rv scan` terminal output includes:
 
 - `ARCHITON SCAN`
 - `Target`, `Result`, `Parts`, `Nets`, `Errors`, `Warnings`, `Rules`, `Violations`
 - compact rail coverage: `Inferred voltages: N Unknown voltage nets: N Rail coverage: LEVEL PCT%`
-- `Detected BOM` and `Detected Netlist` when directory scan auto-detects files
+- `Inferred rails`, `Voltage coverage`, and `Metadata`
+- `Detected BOM`, `Detected Netlist`, and `Generated Netlist` when directory scan auto-detects or exports files
 - rail inference table when `--rails` is passed; `--explain-rails` remains supported as a legacy alias
 
 Example success snippet:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ BINARY := rv
 CMD := ./cmd/rv
 PKG := ./...
 GOFLAGS :=
+GO_BIN := $(shell go env GOBIN)
+GO_PATH := $(shell go env GOPATH)
+INSTALL_BIN ?= $(if $(GO_BIN),$(GO_BIN),$(GO_PATH)/bin)
 
 # Optional overrides:
 #   make run ARGS="check examples/amr_basic.yaml"
@@ -10,7 +13,7 @@ GOFLAGS :=
 ARGS ?=
 FILE ?= examples/amr_parts.yaml
 
-.PHONY: help tidy fmt vet test lint build install run check validate verify version clean
+.PHONY: help tidy fmt vet test lint build install install-rv install-kicad-cli doctor run check validate verify version clean
 
 help:
 	@echo "Targets:"
@@ -20,7 +23,8 @@ help:
 	@echo "  test       - run unit tests"
 	@echo "  lint       - golangci-lint (if installed)"
 	@echo "  build      - build binary into ./bin/$(BINARY)"
-	@echo "  install    - install binary into $${GOBIN:-$$(go env GOPATH)/bin}/$(BINARY)"
+	@echo "  install    - install rv and configure local KiCad CLI discovery"
+	@echo "  doctor     - verify rv and KiCad CLI setup"
 	@echo "  run        - run CLI (requires ARGS=\"...\")"
 	@echo "  check      - run check on FILE (default: $(FILE))"
 	@echo "  validate   - alias for check"
@@ -33,6 +37,7 @@ help:
 	@echo "  make run ARGS=\"check examples/amr_basic.yaml\""
 	@echo "  make run ARGS=\"version\""
 	@echo "  make build && ./bin/$(BINARY) version"
+	@echo "  make install && rv scan /path/to/kicad/project --out report.json"
 	@echo "  rv version"
 	
 
@@ -57,12 +62,60 @@ bin/$(BINARY): $(shell find . -name '*.go')
 
 build: bin/$(BINARY)
 
-install:
+install: install-rv install-kicad-cli doctor
+	@echo ""
+	@echo "Ready. Try:"
+	@echo "  rv scan /path/to/kicad/project --out report.json"
+
+install-rv:
 	go install $(GOFLAGS) $(CMD)
 	@echo ""
-	@echo "Installed to: $${GOBIN:-$$(go env GOPATH)/bin}/$(BINARY)"
-	@echo "If 'rv' is not found, add this to your PATH:"
-	@echo '  export PATH="'"$${GOBIN:-$$(go env GOPATH)/bin}"':$$PATH"'
+	@echo "Installed rv to: $(INSTALL_BIN)/$(BINARY)"
+
+install-kicad-cli:
+	@set -e; \
+	if command -v kicad-cli >/dev/null 2>&1; then \
+		echo "KiCad CLI available: $$(command -v kicad-cli)"; \
+		exit 0; \
+	fi; \
+	candidate=""; \
+	for path in \
+		"/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli" \
+		/Applications/KiCad*/KiCad.app/Contents/MacOS/kicad-cli \
+		/Applications/KiCad/*.app/Contents/MacOS/kicad-cli; do \
+		if [ -x "$$path" ]; then candidate="$$path"; break; fi; \
+	done; \
+	if [ -z "$$candidate" ]; then \
+		echo "KiCad CLI not found in PATH or common macOS app paths."; \
+		echo "rv scan can still run if you pass --kicad-cli /full/path/to/kicad-cli."; \
+		exit 0; \
+	fi; \
+	mkdir -p "$(INSTALL_BIN)"; \
+	link="$(INSTALL_BIN)/kicad-cli"; \
+	if [ -e "$$link" ]; then \
+		echo "kicad-cli already exists at $$link"; \
+	else \
+		ln -s "$$candidate" "$$link"; \
+		echo "Linked kicad-cli: $$link -> $$candidate"; \
+	fi
+
+doctor:
+	@set -e; \
+	echo ""; \
+	if command -v "$(BINARY)" >/dev/null 2>&1; then \
+		echo "rv available: $$(command -v $(BINARY))"; \
+	else \
+		echo "rv is installed at $(INSTALL_BIN)/$(BINARY), but $(INSTALL_BIN) is not on PATH."; \
+		echo 'Add this to your shell profile:'; \
+		echo '  export PATH="$(INSTALL_BIN):$$PATH"'; \
+	fi; \
+	if command -v kicad-cli >/dev/null 2>&1; then \
+		echo "kicad-cli available: $$(command -v kicad-cli)"; \
+	elif [ -x "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli" ]; then \
+		echo "kicad-cli available via KiCad app bundle: /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"; \
+	else \
+		echo "kicad-cli was not found. Install KiCad or run rv scan with --kicad-cli /full/path/to/kicad-cli."; \
+	fi
 	
 run: build
 	@if [ -z "$(strip $(ARGS))" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ GOFLAGS :=
 GO_BIN := $(shell go env GOBIN)
 GO_PATH := $(shell go env GOPATH)
 INSTALL_BIN ?= $(if $(GO_BIN),$(GO_BIN),$(GO_PATH)/bin)
+ifeq ($(OS),Windows_NT)
+EXE := .exe
+BIN_CMD := .\bin\$(BINARY)$(EXE)
+else
+EXE :=
+BIN_CMD := ./bin/$(BINARY)$(EXE)
+endif
 
 # Optional overrides:
 #   make run ARGS="check examples/amr_basic.yaml"
@@ -13,7 +20,7 @@ INSTALL_BIN ?= $(if $(GO_BIN),$(GO_BIN),$(GO_PATH)/bin)
 ARGS ?=
 FILE ?= examples/amr_parts.yaml
 
-.PHONY: help tidy fmt vet test lint build install install-rv install-kicad-cli doctor run check validate verify version clean
+.PHONY: help tidy fmt vet test lint build install install-rv doctor run check validate verify version clean
 
 help:
 	@echo "Targets:"
@@ -23,7 +30,7 @@ help:
 	@echo "  test       - run unit tests"
 	@echo "  lint       - golangci-lint (if installed)"
 	@echo "  build      - build binary into ./bin/$(BINARY)"
-	@echo "  install    - install rv and configure local KiCad CLI discovery"
+	@echo "  install    - install rv and verify local KiCad CLI discovery"
 	@echo "  doctor     - verify rv and KiCad CLI setup"
 	@echo "  run        - run CLI (requires ARGS=\"...\")"
 	@echo "  check      - run check on FILE (default: $(FILE))"
@@ -36,7 +43,7 @@ help:
 	@echo "  make check FILE=examples/amr_basic.yaml"
 	@echo "  make run ARGS=\"check examples/amr_basic.yaml\""
 	@echo "  make run ARGS=\"version\""
-	@echo "  make build && ./bin/$(BINARY) version"
+	@echo "  make build && $(BIN_CMD) version"
 	@echo "  make install && rv scan /path/to/kicad/project --out report.json"
 	@echo "  rv version"
 	
@@ -54,15 +61,12 @@ test:
 	go test $(PKG)
 
 lint:
-	@command -v golangci-lint >/dev/null 2>&1 && golangci-lint run ./... || (echo "golangci-lint not installed. Install: https://golangci-lint.run/usage/install/"; exit 1)
+	golangci-lint run ./...
 
-bin/$(BINARY): $(shell find . -name '*.go')
-	mkdir -p bin
-	go build $(GOFLAGS) -o bin/$(BINARY) $(CMD)
+build:
+	go run ./scripts/build.go $(GOFLAGS)
 
-build: bin/$(BINARY)
-
-install: install-rv install-kicad-cli doctor
+install: install-rv doctor
 	@echo ""
 	@echo "Ready. Try:"
 	@echo "  rv scan /path/to/kicad/project --out report.json"
@@ -70,71 +74,26 @@ install: install-rv install-kicad-cli doctor
 install-rv:
 	go install $(GOFLAGS) $(CMD)
 	@echo ""
-	@echo "Installed rv to: $(INSTALL_BIN)/$(BINARY)"
-
-install-kicad-cli:
-	@set -e; \
-	if command -v kicad-cli >/dev/null 2>&1; then \
-		echo "KiCad CLI available: $$(command -v kicad-cli)"; \
-		exit 0; \
-	fi; \
-	candidate=""; \
-	for path in \
-		"/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli" \
-		/Applications/KiCad*/KiCad.app/Contents/MacOS/kicad-cli \
-		/Applications/KiCad/*.app/Contents/MacOS/kicad-cli; do \
-		if [ -x "$$path" ]; then candidate="$$path"; break; fi; \
-	done; \
-	if [ -z "$$candidate" ]; then \
-		echo "KiCad CLI not found in PATH or common macOS app paths."; \
-		echo "rv scan can still run if you pass --kicad-cli /full/path/to/kicad-cli."; \
-		exit 0; \
-	fi; \
-	mkdir -p "$(INSTALL_BIN)"; \
-	link="$(INSTALL_BIN)/kicad-cli"; \
-	if [ -e "$$link" ]; then \
-		echo "kicad-cli already exists at $$link"; \
-	else \
-		ln -s "$$candidate" "$$link"; \
-		echo "Linked kicad-cli: $$link -> $$candidate"; \
-	fi
+	@echo "Installed rv to: $(INSTALL_BIN)/$(BINARY)$(EXE)"
+	@echo "If 'rv' is not found, add this directory to PATH: $(INSTALL_BIN)"
 
 doctor:
-	@set -e; \
-	echo ""; \
-	if command -v "$(BINARY)" >/dev/null 2>&1; then \
-		echo "rv available: $$(command -v $(BINARY))"; \
-	else \
-		echo "rv is installed at $(INSTALL_BIN)/$(BINARY), but $(INSTALL_BIN) is not on PATH."; \
-		echo 'Add this to your shell profile:'; \
-		echo '  export PATH="$(INSTALL_BIN):$$PATH"'; \
-	fi; \
-	if command -v kicad-cli >/dev/null 2>&1; then \
-		echo "kicad-cli available: $$(command -v kicad-cli)"; \
-	elif [ -x "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli" ]; then \
-		echo "kicad-cli available via KiCad app bundle: /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"; \
-	else \
-		echo "kicad-cli was not found. Install KiCad or run rv scan with --kicad-cli /full/path/to/kicad-cli."; \
-	fi
+	go run $(CMD) doctor
 	
 run: build
-	@if [ -z "$(strip $(ARGS))" ]; then \
-		echo "ERROR: ARGS is required, e.g. make run ARGS=\"check examples/amr_basic.yaml\""; \
-		exit 2; \
-	fi
-	./bin/$(BINARY) $(ARGS)
+	$(BIN_CMD) $(ARGS)
 
 check: build
-	./bin/$(BINARY) check $(FILE)
+	$(BIN_CMD) check $(FILE)
 
 validate: build
-	./bin/$(BINARY) check $(FILE)
+	$(BIN_CMD) check $(FILE)
 
 verify: check
 
 
 version: build
-	./bin/$(BINARY) version
+	$(BIN_CMD) version
 
 clean:
-	rm -rf bin
+	go run ./scripts/build.go --clean

--- a/README.md
+++ b/README.md
@@ -77,9 +77,19 @@ Requires Go **1.25.5** or newer (https://go.dev/dl/).
 ```bash
 go install github.com/badimirzai/architon-cli/cmd/rv@latest
 rv version
+rv doctor
 rv --help
 ```
 
+From a cloned repo, `make install` installs `rv` with Go and runs `rv doctor`:
+
+```bash
+git clone https://github.com/badimirzai/architon-cli.git
+cd architon-cli
+make install
+```
+
+`rv scan .` can generate KiCad netlists automatically when `kicad-cli` is on `PATH` or installed in a common KiCad location on macOS, Linux, or Windows. If KiCad is installed somewhere custom, pass `--kicad-cli /full/path/to/kicad-cli`.
 
 ---
 
@@ -104,12 +114,14 @@ Warnings: 0
 Rules: 0
 Violations: 0
 Inferred voltages: <n> Unknown voltage nets: <n> Rail coverage: <LEVEL> <PCT>%
-Detected Netlist: <path>
+Inferred rails: <n>
+Voltage coverage: <x>/<y> nets with inferred voltage
+Metadata: inferred
+Detected Netlist: <path>       # or Generated Netlist: <temp path>
 Wrote architon-report.json
 exit code: 0
 ```
-Architon automatically detects KiCad .net netlists and BOM CSV files
-and produces a deterministic DesignIR report.
+Architon automatically detects KiCad `.net` netlists and BOM CSV files. If no `.net` file exists, it can export one from a single root `*.kicad_sch` using KiCad CLI and then produce a deterministic DesignIR report.
 
 ### Try the architecture checker (YAML)
 
@@ -196,6 +208,8 @@ rv scan examples/bom/bom.csv --map examples/mapping.yaml
 rv scan examples/bom/bom.csv --out my-report.json
 rv scan exports/project.net --meta .architon/meta.yaml
 rv scan exports/project.net --meta .architon/meta.yaml --rails
+rv scan . --no-kicad-cli
+rv scan . --kicad-cli /full/path/to/kicad-cli
 
 # KiCad project folder scan (demo repo)
 git clone https://github.com/badimirzai/architon-kicad-demo.git demos
@@ -208,7 +222,9 @@ rv scan .
 Architon automatically detects:
 - KiCad .net netlists
 - KiCad BOM CSV files
-and produces a normalized deterministic DesignIR report. 
+- a single root KiCad schematic (`*.kicad_sch`) when no `.net` exists, exported with KiCad CLI
+
+It produces a normalized deterministic DesignIR report. 
 
 `rv scan .` supports three input modes:
 
@@ -220,6 +236,7 @@ When you scan a directory, Architon looks for:
 
 - BOM candidates using the existing BOM detection rules: `bom/bom.csv`, `bom.csv`, `exports/bom.csv`, then lexical `*bom*.csv` matches in `bom/`, `exports/`, and the project root
 - Netlist candidates in this order: lexical `exports/*.net`, then lexical `*.net` in the project root
+- If no netlist is found: exactly one root `*.kicad_sch`, exported with `kicad-cli sch export netlist --format kicadsexpr --output <temp>.net <schematic>`
 
 If both a BOM and a netlist are found, Architon merges them deterministically into one DesignIR:
 
@@ -275,7 +292,7 @@ Example overvoltage output:
 
 ```text
 ARCHITON SCAN
-Target: exports/project.net
+Target: .
 Result: FAIL — scan violations detected
 Parts: 3
 Nets: 3
@@ -284,8 +301,12 @@ Warnings: 0
 Rules: 1
 Violations: 1
 Inferred voltages: 2 Unknown voltage nets: 0 Rail coverage: HIGH 100%
+Inferred rails: 2
+Voltage coverage: 2/3 nets with inferred voltage
+Metadata: mixed
 Rule findings:
 - ERROR RULE_SUPPLY_CONTRACT: Net /+5V provides 5.00V but U1 pin 1 allows max 3.30V
+Generated Netlist: <temp path>
 Wrote architon-report.json
 exit code: 2
 ```
@@ -298,7 +319,7 @@ Default output path: `architon-report.json`.
 
 ### Rail inference and coverage
 
-Rail voltage inference is deterministic and transparent. Each inference includes source, confidence score, evidence, and warnings. Confidence score indicates the reliability of an inference. Coverage indicates how much of the design can be safely checked by voltage rules. Users can inspect details with `--rails`.
+Rail voltage inference is deterministic and transparent. Each inference includes source, confidence score, reason, evidence, and warnings. Confidence score indicates the reliability of an inference. Coverage indicates how much of the design can be safely checked by voltage rules. Users can inspect details with `--rails`.
 
 ```bash
 rv scan example.net
@@ -308,6 +329,9 @@ Expected output:
 
 ```text
 Inferred voltages: 2 Unknown voltage nets: 1 Rail coverage: MEDIUM 67%
+Inferred rails: 2
+Voltage coverage: 2/3 nets with inferred voltage
+Metadata: inferred
 ```
 
 ```bash
@@ -319,7 +343,7 @@ Example detail:
 ```text
 Rail inference:
 
-- /+5V: 5.00V  HIGH   0.95  NET_NAME_EXACT
+- /+5V: 5.00V  HIGH   0.95  net_name
 - VIN:  UNKNOWN LOW    0.35  HEURISTIC
 
 Rail coverage:

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/badimirzai/architon-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check local rv and KiCad CLI setup",
+	Run: func(cmd *cobra.Command, args []string) {
+		out := cmd.OutOrStdout()
+		fmt.Fprintf(out, "Architon doctor\n")
+		fmt.Fprintf(out, "Version: %s\n", version.Line())
+		fmt.Fprintf(out, "Go runtime: %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+		if executable, err := os.Executable(); err == nil {
+			fmt.Fprintf(out, "Executable: %s\n", executable)
+		}
+		if rvPath, err := exec.LookPath("rv"); err == nil {
+			fmt.Fprintf(out, "rv on PATH: %s\n", rvPath)
+		} else {
+			fmt.Fprintf(out, "rv on PATH: not found\n")
+		}
+
+		if kicadCLI, err := resolveKiCadCLIPath(defaultKiCadCLI); err == nil {
+			fmt.Fprintf(out, "KiCad CLI: %s\n", kicadCLI)
+			fmt.Fprintf(out, "KiCad netlist export: available\n")
+		} else {
+			fmt.Fprintf(out, "KiCad CLI: not found\n")
+			fmt.Fprintf(out, "KiCad netlist export: unavailable (%v)\n", err)
+			fmt.Fprintf(out, "Install KiCad, add kicad-cli to PATH, or use rv scan . --kicad-cli /full/path/to/kicad-cli\n")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,9 @@ var rootCmd = &cobra.Command{
 
 Quick help:
   rv check <file.yaml>       Run analysis
-  rv scan <path>             Import KiCad BOM/netlist and emit DesignIR report JSON
+  rv scan <path>             Import KiCad BOM/netlist/schematic and emit DesignIR report JSON
   rv init                    Initialize Architon metadata or write a starter robot spec
+  rv doctor                  Check local rv and KiCad CLI setup
   rv check --output json     Emit JSON findings
   rv version                 Show installed version
   rv --help                  Show all commands and flags`,

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -750,17 +751,54 @@ func resolveKiCadCLIPathWithLookPath(binary string, commonPaths []string, lookPa
 			return candidate, nil
 		}
 	}
-	return "", fmt.Errorf("KiCad CLI %q not found in PATH or common install locations; pass --kicad-cli /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli", binary)
+	return "", fmt.Errorf("KiCad CLI %q not found in PATH or common install locations; install KiCad, add kicad-cli to PATH, or pass --kicad-cli /full/path/to/kicad-cli", binary)
 }
 
 func commonKiCadCLIPaths() []string {
-	candidates := []string{
-		"/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
+	candidates := make([]string, 0, 16)
+	patterns := make([]string, 0, 16)
+
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = append(candidates,
+			"/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
+		)
+		patterns = append(patterns,
+			"/Applications/KiCad*/KiCad.app/Contents/MacOS/kicad-cli",
+			"/Applications/KiCad/*.app/Contents/MacOS/kicad-cli",
+		)
+	case "windows":
+		for _, root := range []string{
+			os.Getenv("ProgramFiles"),
+			os.Getenv("ProgramFiles(x86)"),
+			os.Getenv("LocalAppData"),
+		} {
+			root = strings.TrimSpace(root)
+			if root == "" {
+				continue
+			}
+			candidates = append(candidates,
+				filepath.Join(root, "KiCad", "bin", "kicad-cli.exe"),
+			)
+			patterns = append(patterns,
+				filepath.Join(root, "KiCad", "*", "bin", "kicad-cli.exe"),
+				filepath.Join(root, "KiCad", "*", "kicad-cli.exe"),
+			)
+		}
+	default:
+		candidates = append(candidates,
+			"/usr/bin/kicad-cli",
+			"/usr/local/bin/kicad-cli",
+			"/opt/kicad/bin/kicad-cli",
+			"/snap/bin/kicad-cli",
+			"/app/bin/kicad-cli",
+		)
+		patterns = append(patterns,
+			"/opt/kicad*/bin/kicad-cli",
+		)
 	}
-	for _, pattern := range []string{
-		"/Applications/KiCad*/KiCad.app/Contents/MacOS/kicad-cli",
-		"/Applications/KiCad/*.app/Contents/MacOS/kicad-cli",
-	} {
+
+	for _, pattern := range patterns {
 		matches, err := filepath.Glob(pattern)
 		if err == nil {
 			candidates = append(candidates, matches...)

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -27,7 +28,8 @@ import (
 )
 
 const defaultScanReportPath = "architon-report.json"
-const noScanInputsFoundInProjectDirMessage = "no BOM or netlist file found in project directory (expected bom/bom.csv, bom.csv, exports/bom.csv, or *bom*.csv in root/bom/exports/, plus exports/*.net or *.net in root)"
+const defaultKiCadCLI = "kicad-cli"
+const noScanInputsFoundInProjectDirMessage = "no BOM, netlist, or root KiCad schematic found in project directory (expected bom/bom.csv, bom.csv, exports/bom.csv, or *bom*.csv in root/bom/exports/, plus exports/*.net or *.net in root, or one root *.kicad_sch for kicad-cli netlist export)"
 
 var scanCmd = newScanCmd()
 
@@ -37,8 +39,15 @@ type resolvedScanInput struct {
 	ProjectPath       string
 	BOMPath           string
 	NetlistPath       string
+	SchematicPath     string
 	BOMDiscovered     bool
 	NetlistDiscovered bool
+	NetlistGenerated  bool
+}
+
+type scanInputOptions struct {
+	AutoKiCadNetlist bool
+	KiCadCLIPath     string
 }
 
 func init() {
@@ -55,11 +64,13 @@ func newScanCmd() *cobra.Command {
 Current supported input:
   - KiCad BOM CSV
   - KiCad .net S-expression netlist
+  - KiCad project directory with a root .kicad_sch schematic
 
 Examples:
   rv scan .
   rv scan bom.csv
   rv scan exports/example.net
+  rv scan . --kicad-cli /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli
   rv scan bom.csv --map mapping.yaml
   rv scan bom.csv --out result.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -70,9 +81,14 @@ Examples:
 			metaOverride, _ := cmd.Flags().GetString("meta")
 			explainRails, _ := cmd.Flags().GetBool("explain-rails")
 			railsAlias, _ := cmd.Flags().GetBool("rails")
+			noKiCadCLI, _ := cmd.Flags().GetBool("no-kicad-cli")
+			kicadCLIPath, _ := cmd.Flags().GetString("kicad-cli")
 			explainRails = explainRails || railsAlias
 
-			resolvedInput, err := resolveScanInput(args[0], bomOverride, netlistOverride)
+			resolvedInput, err := resolveScanInputWithOptions(args[0], bomOverride, netlistOverride, scanInputOptions{
+				AutoKiCadNetlist: !noKiCadCLI,
+				KiCadCLIPath:     kicadCLIPath,
+			})
 			if err != nil {
 				return fatalError(err)
 			}
@@ -86,11 +102,11 @@ Examples:
 			nameInferRes := infer.InferVoltagesFromNetNames(design)
 
 			// -------------------------
-			// META: auto-discover + skeleton generation (directory scans only)
+			// META: auto-discover existing metadata only. Scan never writes
+			// .architon/meta.yaml; rv init owns file creation.
 			// -------------------------
 			metaPath := strings.TrimSpace(metaOverride)
 			metaExplicit := metaPath != ""
-			skeletonCreated := false
 
 			if resolvedInput.Directory {
 				defaultMetaPath := filepath.Join(resolvedInput.ProjectPath, ".architon", "meta.yaml")
@@ -100,16 +116,7 @@ Examples:
 					if _, err := os.Stat(defaultMetaPath); err == nil {
 						metaPath = defaultMetaPath
 					} else if os.IsNotExist(err) {
-						// Auto-generate skeleton only if netlist/nets exist
-						if designReport.Summary.Nets > 0 {
-							if err := meta.WriteSkeleton(defaultMetaPath, scanDetectURefs(design)); err != nil {
-								return internalError(fmt.Errorf("create meta skeleton: %w", err))
-							}
-							skeletonCreated = true
-							fmt.Fprintf(cmd.OutOrStdout(), "Created .architon/meta.yaml — fill sources/components to enable voltage rules\n")
-							// Do not load the generated placeholder file on the same run.
-							metaPath = ""
-						}
+						metaPath = ""
 					} else {
 						return internalError(fmt.Errorf("stat default meta: %w", err))
 					}
@@ -125,7 +132,7 @@ Examples:
 			metaObj := &meta.Meta{}
 			metaLoaded := false
 
-			if metaPath != "" && !skeletonCreated {
+			if metaPath != "" {
 				// meta-based rules require nets
 				if designReport.Summary.Nets == 0 {
 					return &ExitError{
@@ -277,6 +284,10 @@ Examples:
 			fmt.Fprintf(cmd.OutOrStdout(), "Rules: %d\n", designReport.Summary.Rules)
 			fmt.Fprintf(cmd.OutOrStdout(), "Violations: %d\n", scanRuleViolationCount(designReport))
 			fmt.Fprintf(cmd.OutOrStdout(), "Inferred voltages: %d Unknown voltage nets: %d Rail coverage: %s\n", len(nameInferRes.Voltages), len(railInferRes.Unknowns), rails.FormatRailCoverage(railCoverage))
+			coveredNets, totalNets := scanInferredVoltageCoverage(design, nameInferRes)
+			fmt.Fprintf(cmd.OutOrStdout(), "Inferred rails: %d\n", len(nameInferRes.Voltages))
+			fmt.Fprintf(cmd.OutOrStdout(), "Voltage coverage: %d/%d nets with inferred voltage\n", coveredNets, totalNets)
+			fmt.Fprintf(cmd.OutOrStdout(), "Metadata: %s\n", scanMetadataMode(metaLoaded, nameInferRes))
 			if explainRails {
 				scanPrintRailInferences(cmd.OutOrStdout(), railInferences, railCoverage)
 			}
@@ -298,6 +309,9 @@ Examples:
 			}
 			if resolvedInput.NetlistDiscovered {
 				fmt.Fprintf(cmd.OutOrStdout(), "Detected Netlist: %s\n", resolvedInput.NetlistPath)
+			}
+			if resolvedInput.NetlistGenerated {
+				fmt.Fprintf(cmd.OutOrStdout(), "Generated Netlist: %s\n", resolvedInput.NetlistPath)
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", outputPath)
@@ -336,9 +350,11 @@ Examples:
 	cmd.Flags().String("out", defaultScanReportPath, "Path to write the scan report JSON")
 	cmd.Flags().String("bom", "", "Override BOM file path when scanning a project directory")
 	cmd.Flags().String("netlist", "", "Override netlist file path when scanning a project directory")
-	cmd.Flags().String("meta", "", "Override meta file path (default: .architon/meta.yaml if present; auto-generated if missing)")
+	cmd.Flags().String("meta", "", "Override meta file path (default: .architon/meta.yaml if present)")
 	cmd.Flags().Bool("explain-rails", false, "Print rail voltage inference provenance and confidence")
 	cmd.Flags().Bool("rails", false, "Alias for --explain-rails")
+	cmd.Flags().Bool("no-kicad-cli", false, "Disable automatic KiCad netlist generation for project directories")
+	cmd.Flags().String("kicad-cli", defaultKiCadCLI, "KiCad CLI binary name or path for automatic netlist generation")
 	return cmd
 }
 
@@ -420,6 +436,10 @@ func loadScanMapping(mappingFile string) (kicad.ColumnMapping, error) {
 }
 
 func resolveScanInput(inputPath string, bomOverride string, netlistOverride string) (resolvedScanInput, error) {
+	return resolveScanInputWithOptions(inputPath, bomOverride, netlistOverride, scanInputOptions{})
+}
+
+func resolveScanInputWithOptions(inputPath string, bomOverride string, netlistOverride string, opts scanInputOptions) (resolvedScanInput, error) {
 	cleanInput := filepath.Clean(inputPath)
 
 	info, statErr := os.Stat(cleanInput)
@@ -462,6 +482,25 @@ func resolveScanInput(inputPath string, bomOverride string, netlistOverride stri
 			return resolvedScanInput{}, err
 		}
 		resolved.NetlistDiscovered = resolved.NetlistPath != ""
+	}
+
+	if netlistOverride == "" && resolved.NetlistPath == "" {
+		schematicPath, err := resolveRootSchematicPath(absInput)
+		if err != nil {
+			return resolvedScanInput{}, err
+		}
+		resolved.SchematicPath = schematicPath
+		if schematicPath != "" && opts.AutoKiCadNetlist {
+			generatedNetlist, err := generateKiCadNetlistFromSchematic(opts.KiCadCLIPath, schematicPath)
+			if err != nil {
+				return resolvedScanInput{}, err
+			}
+			resolved.NetlistPath = generatedNetlist
+			resolved.NetlistGenerated = true
+		}
+		if schematicPath != "" && !opts.AutoKiCadNetlist && resolved.BOMPath == "" {
+			return resolvedScanInput{}, errors.New("root KiCad schematic found but no netlist is available; remove --no-kicad-cli or provide --netlist")
+		}
 	}
 
 	if resolved.BOMPath == "" && resolved.NetlistPath == "" {
@@ -594,6 +633,186 @@ func findNetlistCandidates(dir string) ([]string, error) {
 	return matches, nil
 }
 
+func resolveRootSchematicPath(projectPath string) (string, error) {
+	candidates, err := findRootSchematicCandidates(projectPath)
+	if err != nil {
+		return "", err
+	}
+	if len(candidates) == 0 {
+		return "", nil
+	}
+	if len(candidates) > 1 {
+		rel := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			name, err := filepath.Rel(projectPath, candidate)
+			if err != nil {
+				name = candidate
+			}
+			rel = append(rel, filepath.ToSlash(name))
+		}
+		sort.Strings(rel)
+		return "", fmt.Errorf("multiple root KiCad schematics found; use --netlist or keep one root *.kicad_sch: %s", strings.Join(rel, ", "))
+	}
+	return candidates[0], nil
+}
+
+func findRootSchematicCandidates(projectPath string) ([]string, error) {
+	absDir, err := filepath.Abs(filepath.Clean(projectPath))
+	if err != nil {
+		return nil, fmt.Errorf("resolve schematic candidate directory: %w", err)
+	}
+
+	entries, readErr := os.ReadDir(absDir)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read schematic candidate directory: %w", readErr)
+	}
+
+	matches := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !matchesKiCadSchematicPattern(entry.Name()) {
+			continue
+		}
+		matches = append(matches, filepath.Join(absDir, entry.Name()))
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		left, leftErr := filepath.Rel(absDir, matches[i])
+		right, rightErr := filepath.Rel(absDir, matches[j])
+		if leftErr != nil || rightErr != nil {
+			return filepath.ToSlash(matches[i]) < filepath.ToSlash(matches[j])
+		}
+		return filepath.ToSlash(left) < filepath.ToSlash(right)
+	})
+	return matches, nil
+}
+
+func generateKiCadNetlistFromSchematic(kicadCLIPath string, schematicPath string) (string, error) {
+	tempFile, err := os.CreateTemp("", "architon-kicad-*.net")
+	if err != nil {
+		return "", fmt.Errorf("create temporary KiCad netlist: %w", err)
+	}
+	outputPath := tempFile.Name()
+	if closeErr := tempFile.Close(); closeErr != nil {
+		_ = os.Remove(outputPath)
+		return "", fmt.Errorf("close temporary KiCad netlist: %w", closeErr)
+	}
+
+	if err := runKiCadNetlistExport(kicadCLIPath, schematicPath, outputPath); err != nil {
+		_ = os.Remove(outputPath)
+		return "", err
+	}
+	return outputPath, nil
+}
+
+func runKiCadNetlistExport(kicadCLIPath string, schematicPath string, outputPath string) error {
+	binary, args, err := buildKiCadNetlistCommand(kicadCLIPath, outputPath, schematicPath)
+	if err != nil {
+		return err
+	}
+	resolvedBinary, err := resolveKiCadCLIPath(binary)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(resolvedBinary, args...)
+	output, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		message := strings.TrimSpace(string(output))
+		if message != "" {
+			return fmt.Errorf("run KiCad netlist export %q %s: %w: %s", resolvedBinary, strings.Join(args, " "), runErr, message)
+		}
+		return fmt.Errorf("run KiCad netlist export %q %s: %w", resolvedBinary, strings.Join(args, " "), runErr)
+	}
+	return nil
+}
+
+func resolveKiCadCLIPath(binary string) (string, error) {
+	return resolveKiCadCLIPathWithLookPath(binary, commonKiCadCLIPaths(), exec.LookPath)
+}
+
+func resolveKiCadCLIPathWithLookPath(binary string, commonPaths []string, lookPath func(string) (string, error)) (string, error) {
+	binary = strings.TrimSpace(binary)
+	if binary == "" {
+		binary = defaultKiCadCLI
+	}
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	if resolved, err := lookPath(binary); err == nil {
+		return resolved, nil
+	}
+	if binary != defaultKiCadCLI {
+		return "", fmt.Errorf("KiCad CLI %q not found; pass --kicad-cli with the full path to kicad-cli", binary)
+	}
+	for _, candidate := range commonPaths {
+		if isExecutableFile(candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("KiCad CLI %q not found in PATH or common install locations; pass --kicad-cli /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli", binary)
+}
+
+func commonKiCadCLIPaths() []string {
+	candidates := []string{
+		"/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
+	}
+	for _, pattern := range []string{
+		"/Applications/KiCad*/KiCad.app/Contents/MacOS/kicad-cli",
+		"/Applications/KiCad/*.app/Contents/MacOS/kicad-cli",
+	} {
+		matches, err := filepath.Glob(pattern)
+		if err == nil {
+			candidates = append(candidates, matches...)
+		}
+	}
+	sort.Strings(candidates)
+	out := make([]string, 0, len(candidates))
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		candidate = filepath.Clean(candidate)
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}
+
+func buildKiCadNetlistCommand(kicadCLIPath string, outputPath string, schematicPath string) (string, []string, error) {
+	binary := strings.TrimSpace(kicadCLIPath)
+	if binary == "" {
+		binary = defaultKiCadCLI
+	}
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" {
+		return "", nil, errors.New("KiCad netlist output path is empty")
+	}
+	schematicPath = strings.TrimSpace(schematicPath)
+	if schematicPath == "" {
+		return "", nil, errors.New("KiCad schematic path is empty")
+	}
+	return binary, []string{
+		"sch",
+		"export",
+		"netlist",
+		"--format",
+		"kicadsexpr",
+		"--output",
+		outputPath,
+		schematicPath,
+	}, nil
+}
+
 func matchesBOMCSVPattern(name string) bool {
 	if !strings.EqualFold(filepath.Ext(name), ".csv") {
 		return false
@@ -605,6 +824,10 @@ func matchesBOMCSVPattern(name string) bool {
 
 func matchesNetlistPattern(name string) bool {
 	return strings.EqualFold(filepath.Ext(name), ".net")
+}
+
+func matchesKiCadSchematicPattern(name string) bool {
+	return strings.EqualFold(filepath.Ext(name), ".kicad_sch")
 }
 
 // Exit codes (consistent with rv check contract):
@@ -747,6 +970,9 @@ func scanDetectURefs(design *ir.DesignIR) []string {
 func scanInitialVoltages(inferRes infer.Result, m *meta.Meta) map[string]float64 {
 	initial := make(map[string]float64, len(inferRes.Voltages))
 	for net, inferred := range inferRes.Voltages {
+		if infer.IsGroundNetName(net) {
+			continue
+		}
 		initial[net] = inferred.Voltage
 	}
 	if m != nil {
@@ -755,6 +981,34 @@ func scanInitialVoltages(inferRes infer.Result, m *meta.Meta) map[string]float64
 		}
 	}
 	return initial
+}
+
+func scanInferredVoltageCoverage(design *ir.DesignIR, inferRes infer.Result) (int, int) {
+	if design == nil {
+		return 0, 0
+	}
+	total := len(design.Nets)
+	covered := 0
+	for _, net := range design.Nets {
+		if _, ok := inferRes.Voltages[strings.TrimSpace(net.Name)]; ok {
+			covered++
+		}
+	}
+	return covered, total
+}
+
+func scanMetadataMode(metaLoaded bool, inferRes infer.Result) string {
+	hasInferred := len(inferRes.Voltages) > 0
+	switch {
+	case metaLoaded && hasInferred:
+		return "mixed"
+	case metaLoaded:
+		return "explicit"
+	case hasInferred:
+		return "inferred"
+	default:
+		return "none"
+	}
 }
 
 func scanReportNetVoltages(netVoltages map[string]propagate.NetVoltage) []report.NetVoltage {
@@ -860,9 +1114,11 @@ func scanReportInferredNetVoltages(inferRes infer.Result) []report.NetVoltage {
 	out := make([]report.NetVoltage, 0, len(inferRes.Voltages))
 	for _, inferred := range inferRes.Voltages {
 		out = append(out, report.NetVoltage{
-			Net:     inferred.Net,
-			Voltage: inferred.Voltage,
-			Source:  inferred.Source,
+			Net:        inferred.Net,
+			Voltage:    inferred.Voltage,
+			Source:     inferred.Source,
+			Confidence: inferred.Confidence,
+			Reason:     inferred.Reason,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Net < out[j].Net })
@@ -931,6 +1187,7 @@ func scanReportInferenceProvenance(inference infer.VoltageInference) *report.Inf
 		Source:          inference.Source,
 		ConfidenceScore: inference.ConfidenceScore,
 		ConfidenceLevel: inference.ConfidenceLevel,
+		Reason:          inference.Reason,
 	}
 }
 

--- a/cmd/scan_netlist_discovery_test.go
+++ b/cmd/scan_netlist_discovery_test.go
@@ -1,9 +1,120 @@
 package cmd
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestBuildKiCadNetlistCommand(t *testing.T) {
+	binary, args, err := buildKiCadNetlistCommand("/opt/kicad-cli", "/tmp/out.net", "/work/demo.kicad_sch")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if binary != "/opt/kicad-cli" {
+		t.Fatalf("expected binary override, got %q", binary)
+	}
+	wantArgs := []string{
+		"sch",
+		"export",
+		"netlist",
+		"--format",
+		"kicadsexpr",
+		"--output",
+		"/tmp/out.net",
+		"/work/demo.kicad_sch",
+	}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("unexpected args:\nwant: %#v\n got: %#v", wantArgs, args)
+	}
+}
+
+func TestResolveKiCadCLIPathUsesCommonMacAppPathWhenNotInPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeCLI := writeFakeKiCadCLI(t, tmpDir, kicadFixtureData(t, "netlist_simple.net"))
+
+	got, err := resolveKiCadCLIPathWithLookPath(defaultKiCadCLI, []string{fakeCLI}, func(string) (string, error) {
+		return "", errors.New("not in path")
+	})
+	if err != nil {
+		t.Fatalf("expected fallback path, got %v", err)
+	}
+	if got != fakeCLI {
+		t.Fatalf("expected %q, got %q", fakeCLI, got)
+	}
+}
+
+func TestScan_DirectoryInputGeneratesNetlistFromRootSchematic(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeScanTestFile(t, filepath.Join(tmpDir, "robot.kicad_sch"), "(kicad_sch)")
+	fakeCLI := writeFakeKiCadCLI(t, tmpDir, kicadFixtureData(t, "netlist_simple.net"))
+
+	stdout, err := runScanCommand(t, tmpDir, ".", "--kicad-cli", fakeCLI)
+	if err != nil {
+		t.Fatalf("expected generated netlist scan to succeed, got %v\n%s", err, stdout)
+	}
+	if !strings.Contains(stdout, "Generated Netlist: ") {
+		t.Fatalf("expected generated netlist line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Parts: 3\n") || !strings.Contains(stdout, "Nets: 2\n") {
+		t.Fatalf("expected generated netlist import summary, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Metadata: inferred\n") {
+		t.Fatalf("expected inferred metadata mode, got %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, ".architon", "meta.yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("scan must not write meta.yaml, stat err=%v", err)
+	}
+
+	report := readScanReport(t, filepath.Join(tmpDir, defaultScanReportPath))
+	if report.Summary.Nets != 2 {
+		t.Fatalf("expected generated netlist nets in report, got %d", report.Summary.Nets)
+	}
+}
+
+func TestScan_DirectoryInputNoNetlistNoSchematicReturnsExitCodeThree(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, err := runScanCommand(t, tmpDir, ".")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if exitErr.Code != 3 {
+		t.Fatalf("expected exit code 3, got %d", exitErr.Code)
+	}
+	if exitErr.Err == nil || exitErr.Err.Error() != noScanInputsFoundInProjectDirMessage {
+		t.Fatalf("expected clear no-input error %q, got %v", noScanInputsFoundInProjectDirMessage, exitErr.Err)
+	}
+}
+
+func TestScan_NoKiCadCLIDisablesSchematicNetlistGeneration(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeScanTestFile(t, filepath.Join(tmpDir, "robot.kicad_sch"), "(kicad_sch)")
+
+	_, err := runScanCommand(t, tmpDir, ".", "--no-kicad-cli")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if exitErr.Code != 3 {
+		t.Fatalf("expected exit code 3, got %d", exitErr.Code)
+	}
+	if exitErr.Err == nil || !strings.Contains(exitErr.Err.Error(), "root KiCad schematic found but no netlist is available") {
+		t.Fatalf("expected no-kicad-cli tool error, got %v", exitErr.Err)
+	}
+}
 
 func TestResolveScanInput_ExportsNetlistWinsOverRoot(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -54,4 +165,32 @@ func TestResolveScanInput_NetlistOverrideWins(t *testing.T) {
 	if got.NetlistDiscovered {
 		t.Fatalf("expected override to suppress discovery flag")
 	}
+}
+
+func writeFakeKiCadCLI(t *testing.T, dir string, netlist string) string {
+	t.Helper()
+	path := filepath.Join(dir, "fake-kicad-cli")
+	script := `#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      shift
+      out="$1"
+      ;;
+  esac
+  shift
+done
+if [ -z "$out" ]; then
+  echo "missing --output" >&2
+  exit 64
+fi
+cat > "$out" <<'ARCHITON_NETLIST'
+` + netlist + `
+ARCHITON_NETLIST
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake kicad-cli: %v", err)
+	}
+	return path
 }

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -43,6 +43,7 @@ type scanReport struct {
 			Source          string  `json:"source"`
 			ConfidenceScore float64 `json:"confidence_score"`
 			ConfidenceLevel string  `json:"confidence_level"`
+			Reason          string  `json:"reason"`
 		} `json:"inference"`
 	} `json:"rules"`
 	Derived *struct {
@@ -52,9 +53,11 @@ type scanReport struct {
 			Source  string  `json:"source"`
 		} `json:"net_voltages"`
 		InferredNetVoltages []struct {
-			Net     string  `json:"net"`
-			Voltage float64 `json:"voltage"`
-			Source  string  `json:"source"`
+			Net        string  `json:"net"`
+			Voltage    float64 `json:"voltage"`
+			Source     string  `json:"source"`
+			Confidence string  `json:"confidence"`
+			Reason     string  `json:"reason"`
 		} `json:"inferred_net_voltages"`
 		UnknownVoltageNets []struct {
 			Net    string `json:"net"`
@@ -66,6 +69,7 @@ type scanReport struct {
 			Source          string   `json:"source"`
 			ConfidenceScore float64  `json:"confidence_score"`
 			ConfidenceLevel string   `json:"confidence_level"`
+			Reason          string   `json:"reason"`
 			Evidence        []string `json:"evidence"`
 			Warnings        []string `json:"warnings"`
 		} `json:"rail_inferences"`
@@ -515,6 +519,15 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 	if !strings.Contains(stdout, "Inferred voltages: 2 Unknown voltage nets: 1 Rail coverage: LOW 67%\n") {
 		t.Fatalf("expected voltage inference counts, got %q", stdout)
 	}
+	if !strings.Contains(stdout, "Inferred rails: 2\n") {
+		t.Fatalf("expected inferred rails line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Voltage coverage: 2/3 nets with inferred voltage\n") {
+		t.Fatalf("expected voltage coverage line, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Metadata: inferred\n") {
+		t.Fatalf("expected inferred metadata mode, got %q", stdout)
+	}
 	if strings.Contains(stdout, "Rail inference:\n") {
 		t.Fatalf("expected default output to stay compact, got %q", stdout)
 	}
@@ -531,8 +544,11 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 			if nv.Voltage != 5.0 {
 				t.Fatalf("expected /+5V inferred as 5.0, got %v", nv.Voltage)
 			}
-			if nv.Source != "NET_NAME_EXACT" {
-				t.Fatalf("expected inferred source NET_NAME_EXACT, got %q", nv.Source)
+			if nv.Source != "net_name" {
+				t.Fatalf("expected inferred source net_name, got %q", nv.Source)
+			}
+			if nv.Confidence != "HIGH" || nv.Reason == "" {
+				t.Fatalf("expected inferred voltage provenance, got %+v", nv)
 			}
 		}
 	}
@@ -559,11 +575,14 @@ func TestScan_NetlistReportsInferredAndUnknownVoltageNets(t *testing.T) {
 		if inference.Voltage == nil || *inference.Voltage != 5.0 {
 			t.Fatalf("expected /+5V rail inference voltage 5.0, got %+v", inference.Voltage)
 		}
-		if inference.Source != "NET_NAME_EXACT" {
-			t.Fatalf("expected /+5V rail inference source NET_NAME_EXACT, got %q", inference.Source)
+		if inference.Source != "net_name" {
+			t.Fatalf("expected /+5V rail inference source net_name, got %q", inference.Source)
 		}
 		if inference.ConfidenceLevel != "HIGH" || inference.ConfidenceScore != 0.95 {
 			t.Fatalf("expected /+5V high confidence score 0.95, got %+v", inference)
+		}
+		if inference.Reason == "" {
+			t.Fatalf("expected /+5V inference reason, got %+v", inference)
 		}
 	}
 	if !foundRailInference {
@@ -604,13 +623,13 @@ components:
 	if !strings.Contains(stdout, "Rail inference:\n") {
 		t.Fatalf("expected rail inference header, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "- /+5V: 5.00V  HIGH   0.95  NET_NAME_EXACT\n") {
+	if !strings.Contains(stdout, "- /+5V: 5.00V  HIGH   0.95  net_name\n") {
 		t.Fatalf("expected /+5V rail line, got %q", stdout)
 	}
 	if !strings.Contains(stdout, "- /VBAT: 24.00V HIGH   1.00  USER_OVERRIDE\n") {
 		t.Fatalf("expected /VBAT rail line, got %q", stdout)
 	}
-	if !strings.Contains(stdout, "- GND:   0.00V  HIGH   0.95  NET_NAME_EXACT\n") {
+	if !strings.Contains(stdout, "- GND:   0.00V  HIGH   0.95  net_name\n") {
 		t.Fatalf("expected GND rail line, got %q", stdout)
 	}
 	if !strings.Contains(stdout, "Rail coverage:\n") {
@@ -666,11 +685,14 @@ components:
 	if report.Rules[0].Inference.NetName != "/+5V" {
 		t.Fatalf("expected inference net /+5V, got %+v", report.Rules[0].Inference)
 	}
-	if report.Rules[0].Inference.Source != "NET_NAME_EXACT" {
-		t.Fatalf("expected inference source NET_NAME_EXACT, got %+v", report.Rules[0].Inference)
+	if report.Rules[0].Inference.Source != "net_name" {
+		t.Fatalf("expected inference source net_name, got %+v", report.Rules[0].Inference)
 	}
 	if report.Rules[0].Inference.ConfidenceLevel != "HIGH" || report.Rules[0].Inference.ConfidenceScore != 0.95 {
 		t.Fatalf("expected high confidence inference, got %+v", report.Rules[0].Inference)
+	}
+	if report.Rules[0].Inference.Reason == "" {
+		t.Fatalf("expected inference reason provenance, got %+v", report.Rules[0].Inference)
 	}
 }
 
@@ -821,6 +843,15 @@ func TestScanExitCode(t *testing.T) {
 				},
 			},
 			want: 2,
+		},
+		{
+			name: "warning only",
+			report: reportpkg.VerificationReport{
+				Rules: []reportpkg.RuleResult{
+					{ID: "BOM_RULE", Severity: "warning", Message: "check part"},
+				},
+			},
+			want: 1,
 		},
 		{
 			name:   "clean scan",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ spec.yaml
 
 bom.csv / project.net / project directory
   -> KiCad BOM and/or netlist importer
+  -> optional KiCad CLI schematic netlist export when no .net exists
   -> DesignIR (stable internal model)
   -> deterministic rail inference + metadata-backed voltage rules
   -> deterministic report payload
@@ -115,6 +116,8 @@ Primary command:
 - `rv scan <bom.csv> --out my-report.json`
 - `rv scan <netlist.net> --meta .architon/meta.yaml`
 - `rv scan <netlist.net> --rails`
+- `rv scan . --kicad-cli /full/path/to/kicad-cli`
+- `rv doctor`
 
 Output modes:
 
@@ -135,7 +138,7 @@ Exit behavior is documented in the canonical exit code table in `README.md`.
 - `summary.nets` and `design_ir.nets` for netlist-backed scans
 - `summary.next_steps` only on parse failure
 - `derived.net_voltages`, `derived.inferred_net_voltages`, `derived.unknown_voltage_nets`, `derived.rail_inferences`, and `derived.rail_coverage` when voltage inference data is present
-- optional `rules[].inference` provenance for voltage-based findings
+- optional `rules[].inference` provenance for voltage-based findings, including reason when available
 
 Successful CLI output also prints a short deterministic terminal summary with:
 
@@ -149,7 +152,9 @@ Successful CLI output also prints a short deterministic terminal summary with:
 - `Rules`
 - `Violations`
 - compact rail coverage counts and level
+- inferred rails, voltage coverage, and metadata mode
 - `Detected BOM` / `Detected Netlist` for directory auto-detection
+- `Generated Netlist` when `rv scan .` exports a temporary netlist from `*.kicad_sch`
 
 `--rails` prints the sorted rail inference table with voltage, confidence level, confidence score, source, warnings, and rail coverage summary. `--explain-rails` remains supported as a legacy alias.
 
@@ -195,7 +200,7 @@ Example failure snippet:
 - `internal/contracts`: importer-agnostic component, pin, and net contract schema
 - `internal/enrichment`: pluggable contract sources such as `meta.yaml`, inferred rail voltages, future databases, or UI input
 - `internal/rules`: contract-level rules that consume only DesignIR + ContractIR
-- `cmd/scan.go`: deterministic single-file or project-directory scan input resolution
+- `cmd/scan.go`: deterministic single-file or project-directory scan input resolution, including optional KiCad CLI netlist export from one root `*.kicad_sch`
 - `internal/ir`: deterministic BOM + netlist merge into one project-level DesignIR
 - `internal/infer`: deterministic net-name and metadata-enriched rail voltage inference
 - `internal/rails`: pure rail coverage summary and terminal explanation formatting
@@ -205,7 +210,7 @@ Example failure snippet:
 
 Architon performs deterministic analysis.
 Rail voltage inference is deterministic and transparent.
-Each inference includes source, confidence score, evidence, and warnings.
+Each inference includes source, confidence score, reason, evidence, and warnings.
 No probabilistic models or network calls are used.
 
 Same input spec or scan input + same metadata/part library -> same output findings and exit code.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -105,14 +105,14 @@ Rules:
 
 ## Scan voltage rules (`rv scan`)
 
-Netlist-backed scans can run deterministic contract rules when rail voltages are inferred from net names and/or supplied by `.architon/meta.yaml` / `--meta`.
+Netlist-backed scans can run deterministic contract rules when rail voltages are inferred from net names and/or supplied by `.architon/meta.yaml` / `--meta`. Project scans can generate a temporary KiCad netlist from one root `*.kicad_sch` when no `.net` file exists.
 
 - `RULE_SUPPLY_CONTRACT` (`ERROR`): provider voltage on a net is outside a consumer pin's contracted voltage range
 - `RULE_LOGIC_LEVEL_CONTRACT` (`ERROR`): output logic voltage exceeds an input pin's contracted tolerance
 - `RULE_BUS_ROLE_CONTRACT` (`WARNING`/`ERROR`): obvious I2C role/direction conflicts without guessing when data is missing
 - `RULE_VOLTAGE_CONFLICT` (`ERROR`): metadata, inferred, or propagated voltage evidence conflicts on a net
 
-Voltage-based findings include inference provenance when available: net name, source, confidence score, and confidence level.
+Voltage-based findings include inference provenance when available: net name, source, confidence score, confidence level, and reason.
 
 ## Determinism contract
 
@@ -126,7 +126,7 @@ the engine returns the same findings and exit code.
 
 Architon performs deterministic analysis.
 Rail voltage inference is deterministic and transparent.
-Each inference includes source, confidence score, evidence, and warnings.
+Each inference includes source, confidence score, reason, evidence, and warnings.
 No probabilistic models or network calls are used.
 
 ## Extensibility

--- a/internal/infer/infer.go
+++ b/internal/infer/infer.go
@@ -16,6 +16,7 @@ const ambiguousPowerNetReason = "ambiguous power net name"
 const multipleCandidateVoltagesReason = "multiple candidate voltages detected"
 
 const (
+	SourceNetName               = "net_name"
 	SourceUserOverride          = "USER_OVERRIDE"
 	SourceNetNameExact          = "NET_NAME_EXACT"
 	SourceRegulatorOutput       = "REGULATOR_OUTPUT"
@@ -45,6 +46,7 @@ const (
 var (
 	decimalVoltagePattern = regexp.MustCompile(`^\+?([0-9]+(?:\.[0-9]+)?)V$`)
 	vDecimalPattern       = regexp.MustCompile(`^\+?([0-9]+)V([0-9]+)$`)
+	voltageSuffixPattern  = regexp.MustCompile(`(\+?(?:[0-9]+(?:\.[0-9]+)?V|[0-9]+V[0-9]+))$`)
 )
 
 var ambiguousPowerNetNames = map[string]struct{}{
@@ -67,6 +69,25 @@ var genericRailNameTokens = map[string]struct{}{
 	"SUPPLY": {},
 }
 
+var groundNetNames = map[string]struct{}{
+	"GND":  {},
+	"AGND": {},
+	"DGND": {},
+}
+
+var contextualRailNameTokens = map[string]struct{}{
+	"VCC":  {},
+	"VDD":  {},
+	"USB":  {},
+	"VBUS": {},
+}
+
+var contextualRailNamePrefixes = []string{
+	"VCC",
+	"VDD",
+	"USB",
+}
+
 var knownSemanticAliases = map[string]float64{
 	"VBUS": 5.0,
 }
@@ -77,9 +98,11 @@ var weakSemanticAliases = map[string]struct{}{
 }
 
 type InferredVoltage struct {
-	Net     string
-	Voltage float64
-	Source  string
+	Net        string
+	Voltage    float64
+	Source     string
+	Confidence string
+	Reason     string
 }
 
 type UnknownVoltage struct {
@@ -102,6 +125,7 @@ type VoltageInference struct {
 	Source          string   `json:"source"`
 	ConfidenceScore float64  `json:"confidence_score"`
 	ConfidenceLevel string   `json:"confidence_level"`
+	Reason          string   `json:"reason"`
 	Evidence        []string `json:"evidence"`
 	Warnings        []string `json:"warnings"`
 }
@@ -210,9 +234,11 @@ func InferVoltages(design *ir.DesignIR, opts VoltageInferenceOptions) Result {
 		result.Inferences = append(result.Inferences, inference)
 		if inference.Voltage != nil {
 			result.Voltages[netName] = InferredVoltage{
-				Net:     netName,
-				Voltage: *inference.Voltage,
-				Source:  inference.Source,
+				Net:        netName,
+				Voltage:    *inference.Voltage,
+				Source:     inference.Source,
+				Confidence: inference.ConfidenceLevel,
+				Reason:     inference.Reason,
 			}
 			continue
 		}
@@ -279,7 +305,7 @@ func (s *inferenceState) addNetNameEvidence() {
 		return
 	}
 
-	if s.normalized == "GND" {
+	if IsGroundNetName(s.netName) {
 		s.addCandidate(0, SourceNetNameExact, scoreNetNameExact)
 		s.addEvidence(fmt.Sprintf("matched ground net %q", s.netName))
 		return
@@ -308,13 +334,19 @@ func (s *inferenceState) addNetNameEvidence() {
 	voltageTokens := voltageTokens(s.normalized)
 	if len(voltageTokens) > 0 {
 		s.hasHeuristicExtraction = true
+		source := SourceAmbiguousNumericToken
+		score := scoreAmbiguousNumericToken
+		if hasContextualRailName(s.normalized) {
+			source = SourceSemanticAlias
+			score = scoreSemanticAlias
+		}
 		for _, token := range voltageTokens {
 			voltage, ok := parseVoltageToken(token)
 			if !ok {
 				continue
 			}
-			s.addCandidate(voltage, SourceAmbiguousNumericToken, scoreAmbiguousNumericToken)
-			s.addEvidence(fmt.Sprintf("matched ambiguous voltage token %q in net name %q", token, s.netName))
+			s.addCandidate(voltage, source, score)
+			s.addEvidence(fmt.Sprintf("matched voltage token %q in net name %q", token, s.netName))
 		}
 	}
 }
@@ -408,7 +440,6 @@ func (s *inferenceState) finalize() VoltageInference {
 		s.addWarning("multiple candidate voltages detected")
 	}
 	if s.hasHeuristicExtraction {
-		score -= 0.30
 		s.addWarning("heuristic-only voltage extraction used")
 	}
 	if s.hasConflict {
@@ -426,13 +457,15 @@ func (s *inferenceState) finalize() VoltageInference {
 
 	sort.Strings(s.evidence)
 	sort.Strings(s.warnings)
+	reason := inferenceReason(s.evidence, s.warnings, voltage)
 
 	return VoltageInference{
 		NetName:         s.netName,
 		Voltage:         voltage,
-		Source:          source,
+		Source:          reportInferenceSource(source),
 		ConfidenceScore: score,
 		ConfidenceLevel: confidenceLevel(score),
+		Reason:          reason,
 		Evidence:        stableStrings(s.evidence),
 		Warnings:        stableStrings(s.warnings),
 	}
@@ -442,6 +475,11 @@ func normalizeNetName(netName string) string {
 	trimmed := strings.TrimSpace(netName)
 	trimmed = strings.TrimPrefix(trimmed, "/")
 	return strings.ToUpper(trimmed)
+}
+
+func IsGroundNetName(netName string) bool {
+	_, ok := groundNetNames[normalizeNetName(netName)]
+	return ok
 }
 
 func isAmbiguousPowerNetName(normalized string) bool {
@@ -466,7 +504,7 @@ func parseExactVoltage(normalized string) (float64, bool) {
 }
 
 func parseExplicitVoltage(normalized string) (float64, bool) {
-	if normalized == "GND" {
+	if IsGroundNetName(normalized) {
 		return 0, true
 	}
 	return parseExactVoltage(normalized)
@@ -492,18 +530,40 @@ func voltageTokens(normalized string) []string {
 	tokens := splitNetNameTokens(normalized)
 	out := make([]string, 0, len(tokens))
 	seen := map[string]struct{}{}
-	for _, token := range tokens {
+	add := func(token string) {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return
+		}
 		if _, ok := parseVoltageToken(token); !ok {
-			continue
+			return
 		}
 		if _, ok := seen[token]; ok {
-			continue
+			return
 		}
 		seen[token] = struct{}{}
 		out = append(out, token)
 	}
+	for _, token := range tokens {
+		add(token)
+		if suffix, ok := voltageSuffixToken(token); ok {
+			add(suffix)
+		}
+	}
 	sort.Strings(out)
 	return out
+}
+
+func voltageSuffixToken(token string) (string, bool) {
+	token = strings.ToUpper(strings.TrimSpace(token))
+	matches := voltageSuffixPattern.FindStringSubmatch(token)
+	if len(matches) != 2 {
+		return "", false
+	}
+	if matches[1] == token {
+		return "", false
+	}
+	return matches[1], true
 }
 
 func splitNetNameTokens(normalized string) []string {
@@ -532,8 +592,25 @@ func hasGenericRailName(normalized string) bool {
 	return false
 }
 
+func hasContextualRailName(normalized string) bool {
+	for _, token := range splitNetNameTokens(normalized) {
+		if _, ok := contextualRailNameTokens[token]; ok {
+			return true
+		}
+		for _, prefix := range contextualRailNamePrefixes {
+			if strings.HasPrefix(token, prefix) && len(token) > len(prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func shouldApplyGenericDowngrade(s *inferenceState) bool {
 	if !s.hasGenericRailName {
+		return false
+	}
+	if s.hasHeuristicExtraction {
 		return false
 	}
 	// Plain unknown signal names should not be penalized just because a token
@@ -628,6 +705,28 @@ func defaultScoreForSource(source string) float64 {
 	default:
 		return scoreUnknown
 	}
+}
+
+func reportInferenceSource(source string) string {
+	switch source {
+	case SourceNetNameExact, SourceSemanticAlias, SourceWeakSemanticAlias, SourceAmbiguousNumericToken:
+		return SourceNetName
+	default:
+		return source
+	}
+}
+
+func inferenceReason(evidence []string, warnings []string, voltage *float64) string {
+	if len(evidence) > 0 {
+		return evidence[0]
+	}
+	if len(warnings) > 0 {
+		return warnings[0]
+	}
+	if voltage != nil {
+		return "deterministic voltage inference"
+	}
+	return "no deterministic voltage inference"
 }
 
 func unknownVoltageReason(s *inferenceState, inference VoltageInference) (string, bool) {

--- a/internal/infer/infer_test.go
+++ b/internal/infer/infer_test.go
@@ -14,12 +14,19 @@ func TestInferVoltagesFromNetNames(t *testing.T) {
 		voltage float64
 		source  string
 	}{
-		{net: "/+5V", voltage: 5.0, source: SourceNetNameExact},
-		{net: "3V3", voltage: 3.3, source: SourceNetNameExact},
-		{net: "/+3.3V", voltage: 3.3, source: SourceNetNameExact},
-		{net: "VBAT_24V", voltage: 24.0, source: SourceAmbiguousNumericToken},
-		{net: "/+4.24554V", voltage: 4.24554, source: SourceNetNameExact},
-		{net: "GND", voltage: 0.0, source: SourceNetNameExact},
+		{net: "/+5V", voltage: 5.0, source: SourceNetName},
+		{net: "3V3", voltage: 3.3, source: SourceNetName},
+		{net: "VDD_3V3", voltage: 3.3, source: SourceNetName},
+		{net: "VCC5V", voltage: 5.0, source: SourceNetName},
+		{net: "USB_5V", voltage: 5.0, source: SourceNetName},
+		{net: "VBUS", voltage: 5.0, source: SourceNetName},
+		{net: "/+3.3V", voltage: 3.3, source: SourceNetName},
+		{net: "/3.3V", voltage: 3.3, source: SourceNetName},
+		{net: "VBAT_24V", voltage: 24.0, source: SourceNetName},
+		{net: "/+4.24554V", voltage: 4.24554, source: SourceNetName},
+		{net: "GND", voltage: 0.0, source: SourceNetName},
+		{net: "AGND", voltage: 0.0, source: SourceNetName},
+		{net: "DGND", voltage: 0.0, source: SourceNetName},
 	}
 
 	for _, tt := range tests {
@@ -37,6 +44,12 @@ func TestInferVoltagesFromNetNames(t *testing.T) {
 			}
 			if got.Source != tt.source {
 				t.Fatalf("expected source %s, got %q", tt.source, got.Source)
+			}
+			if got.Confidence == "" {
+				t.Fatalf("expected confidence provenance, got %+v", got)
+			}
+			if got.Reason == "" {
+				t.Fatalf("expected reason provenance, got %+v", got)
 			}
 			if len(result.Unknowns) != 0 {
 				t.Fatalf("expected no unknowns, got %+v", result.Unknowns)
@@ -103,7 +116,7 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 			name:     "slash plus 5V",
 			net:      "/+5V",
 			voltage:  ptr(5.0),
-			source:   SourceNetNameExact,
+			source:   SourceNetName,
 			score:    0.95,
 			level:    ConfidenceHigh,
 			evidence: `matched exact voltage pattern "/+5V"`,
@@ -112,7 +125,7 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 			name:     "plus 5V",
 			net:      "+5V",
 			voltage:  ptr(5.0),
-			source:   SourceNetNameExact,
+			source:   SourceNetName,
 			score:    0.95,
 			level:    ConfidenceHigh,
 			evidence: `matched exact voltage pattern "+5V"`,
@@ -121,7 +134,7 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 			name:     "bare 5V",
 			net:      "5V",
 			voltage:  ptr(5.0),
-			source:   SourceNetNameExact,
+			source:   SourceNetName,
 			score:    0.95,
 			level:    ConfidenceHigh,
 			evidence: `matched exact voltage pattern "5V"`,
@@ -130,7 +143,7 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 			name:     "slash 3V3",
 			net:      "/3V3",
 			voltage:  ptr(3.3),
-			source:   SourceNetNameExact,
+			source:   SourceNetName,
 			score:    0.95,
 			level:    ConfidenceHigh,
 			evidence: `matched exact voltage pattern "/3V3"`,
@@ -139,17 +152,17 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 			name:     "VCC 3V3",
 			net:      "VCC_3V3",
 			voltage:  ptr(3.3),
-			source:   SourceAmbiguousNumericToken,
-			score:    0.00,
-			level:    ConfidenceUnknown,
-			evidence: `matched ambiguous voltage token "3V3" in net name "VCC_3V3"`,
+			source:   SourceNetName,
+			score:    0.80,
+			level:    ConfidenceMedium,
+			evidence: `matched voltage token "3V3" in net name "VCC_3V3"`,
 			warning:  "heuristic-only voltage extraction used",
 		},
 		{
 			name:     "VBUS",
 			net:      "VBUS",
 			voltage:  ptr(5.0),
-			source:   SourceSemanticAlias,
+			source:   SourceNetName,
 			score:    0.80,
 			level:    ConfidenceMedium,
 			evidence: `matched known semantic alias "VBUS" = 5.00V`,
@@ -165,7 +178,7 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 		{
 			name:     "VDD",
 			net:      "VDD",
-			source:   SourceWeakSemanticAlias,
+			source:   SourceNetName,
 			score:    0.45,
 			level:    ConfidenceLow,
 			evidence: `matched weak semantic alias "VDD"`,
@@ -175,16 +188,16 @@ func TestInferVoltageFromNetName_ConfidenceScoring(t *testing.T) {
 			name:     "SUPPLY 4V7",
 			net:      "SUPPLY_4V7",
 			voltage:  ptr(4.7),
-			source:   SourceAmbiguousNumericToken,
-			score:    0.00,
-			level:    ConfidenceUnknown,
-			evidence: `matched ambiguous voltage token "4V7" in net name "SUPPLY_4V7"`,
-			warning:  `generic rail name "SUPPLY_4V7" reduces confidence`,
+			source:   SourceNetName,
+			score:    0.40,
+			level:    ConfidenceLow,
+			evidence: `matched voltage token "4V7" in net name "SUPPLY_4V7"`,
+			warning:  "heuristic-only voltage extraction used",
 		},
 		{
 			name:    "multiple candidates",
 			net:     "RAIL_3V3_5V",
-			source:  SourceAmbiguousNumericToken,
+			source:  SourceNetName,
 			score:   0.00,
 			level:   ConfidenceUnknown,
 			warning: "multiple candidate voltages detected",
@@ -220,7 +233,18 @@ func TestInferVoltageFromNetName_ExactNumericExamples(t *testing.T) {
 	}
 	for net, voltage := range tests {
 		got := InferVoltageFromNetName(net)
-		assertVoltageInference(t, got, net, ptr(voltage), SourceNetNameExact, 0.95, ConfidenceHigh)
+		assertVoltageInference(t, got, net, ptr(voltage), SourceNetName, 0.95, ConfidenceHigh)
+	}
+}
+
+func TestInferVoltageFromNetName_DecimalVoltageParsing(t *testing.T) {
+	tests := map[string]float64{
+		"/+4.24554V": 4.24554,
+		"/3.3V":      3.3,
+	}
+	for net, voltage := range tests {
+		got := InferVoltageFromNetName(net)
+		assertVoltageInference(t, got, net, ptr(voltage), SourceNetName, 0.95, ConfidenceHigh)
 	}
 }
 
@@ -302,6 +326,9 @@ func assertVoltageInference(t *testing.T, got VoltageInference, net string, volt
 	}
 	if got.ConfidenceLevel != level {
 		t.Fatalf("expected level %s, got %s", level, got.ConfidenceLevel)
+	}
+	if voltage != nil && got.Reason == "" {
+		t.Fatalf("expected reason provenance for inferred voltage, got %+v", got)
 	}
 }
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -35,6 +35,7 @@ type InferenceProvenance struct {
 	Source          string  `json:"source"`
 	ConfidenceScore float64 `json:"confidence_score"`
 	ConfidenceLevel string  `json:"confidence_level"`
+	Reason          string  `json:"reason,omitempty"`
 }
 
 // Summary is the compact report header used by both JSON and CLI output.
@@ -79,9 +80,11 @@ type Derived struct {
 
 // NetVoltage is report-facing voltage evidence for a net.
 type NetVoltage struct {
-	Net     string  `json:"net"`
-	Voltage float64 `json:"voltage"`
-	Source  string  `json:"source"`
+	Net        string  `json:"net"`
+	Voltage    float64 `json:"voltage"`
+	Source     string  `json:"source"`
+	Confidence string  `json:"confidence,omitempty"`
+	Reason     string  `json:"reason,omitempty"`
 }
 
 // UnknownVoltageNet explains why a rail-like net could not be assigned voltage.

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--clean" {
+		if err := os.RemoveAll("bin"); err != nil {
+			fmt.Fprintf(os.Stderr, "clean bin: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := os.MkdirAll("bin", 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "create bin: %v\n", err)
+		os.Exit(1)
+	}
+
+	name := "rv"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	args := append([]string{"build"}, os.Args[1:]...)
+	args = append(args, "-o", filepath.Join("bin", name), "./cmd/rv")
+	cmd := exec.Command("go", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "go build: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This PR makes rv scan . useful on real KiCad repositories that do not commit exported .net files. Directory scans now detect a single root *.kicad_sch when no .net exists, invoke KiCad CLI to export a temporary KiCad S-expression netlist, and continue through the existing import, inference, rules, report, and exit-code flow.

It also improves voltage inference and scan reporting. Net-name voltage inference now covers common rail patterns such as 3V3, VDD_3V3, VCC5V, USB_5V, VBUS, decimal rails like /+4.24554V, and ground aliases. Inferred voltage records now carry explicit provenance: source, confidence, and reason. If meta.yaml exists, explicit metadata continues to take precedence; if it is absent, inference is used in memory only and no metadata file is written.

Setup and documentation were updated so cloned repos and installed binaries work more reliably across platforms. rv doctor now checks local rv and KiCad CLI discovery, make install installs rv and runs the doctor check, and KiCad CLI lookup supports PATH plus common macOS, Linux, and Windows install locations.