### PR TITLE
feat/GraphIR with Contract Finding Rollups

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -12,6 +12,9 @@ rv check <file.yaml> --output json --out-file report.json
 rv check <file.yaml> --output json --pretty --out-file report.json
                                       Pretty JSON to stdout + compact JSON to file
 rv scan <path>                         Import KiCad BOM CSV, KiCad .net, or project directory
+rv graph <path> --format json          Emit stable architecture GraphIR JSON
+rv graph <path> --format json --out graph.json
+                                      Write GraphIR JSON to file and stdout
 rv scan <bom.csv> --map mapping.yaml   Use explicit header mapping YAML
 rv scan <bom.csv> --out report.json    Write scan report to a specific path
 rv scan <netlist.net> --meta .architon/meta.yaml
@@ -35,6 +38,7 @@ rv version                             Show installed version
 rv --help                              Show all commands and flags
 rv check --help                        Show check command options
 rv scan --help                         Show scan command options
+rv graph --help                        Show graph command options
 ```
 
 ## Output flags (check command)
@@ -66,6 +70,20 @@ rv scan --help                         Show scan command options
 --out <report.json>       write scan report to a specific path
 ```
 
+## Graph flags (graph command)
+
+```text
+--format json             print GraphIR JSON to stdout
+--out <graph.json>        write GraphIR JSON to a specific path and stdout
+--map <file.yaml>         explicit BOM header mapping file
+--bom <file>              override BOM file path for project directory scans
+--netlist <file>          override netlist file path for project directory scans
+--meta <file.yaml>        metadata for sources, regulators, and component limits
+--contracts <file.yaml>   custom deterministic contracts
+--no-kicad-cli            disable automatic schematic netlist generation
+--kicad-cli <path>        override KiCad CLI binary name/path
+```
+
 Exit behavior is documented in `README.md`.
 
 ## Examples
@@ -86,6 +104,7 @@ rv scan bom.csv --map examples/mapping.yaml
 rv scan bom.csv --out my-report.json
 rv scan exports/project.net --meta .architon/meta.yaml --rails
 rv scan . --contracts i2c_pullup_policy.yaml --verbose
+rv graph . --contracts examples/contracts/i2c_policy.yaml --format json --out graph.json
 rv init
 rv init --template 4wd-problem
 rv check robot.yaml

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Core commands:
 ```text
 rv check <file.yaml>       Run deterministic analysis
 rv scan <path>             Import KiCad/BOM data and emit DesignIR report
+rv graph <path>            Emit stable GraphIR JSON for Studio/renderers
 rv contracts validate      Validate contracts schema
 rv parts list              List built-in contract parts
 rv parts show <mpn>        Show one built-in contract part
@@ -132,9 +133,10 @@ rv version                 Show installed version
 ```
 Detailed CLI examples, scan behavior, import modes, rail inference, and advanced flags are documented in:
 
-- [docs/cli.md](docs/cli.md)
+- [docs/CLI.md](docs/CLI.md)
 - [docs/contracts.md](docs/contracts.md)
 - [docs/ci.md](docs/ci.md)
+- [docs/graph-ir.md](docs/graph-ir.md)
 - [docs/importers.md](docs/importers.md)
 - [docs/rail-inference.md](docs/rail-inference.md)
 - [docs/report-format.md](docs/report-format.md)

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	graphir "github.com/badimirzai/architon-cli/internal/graph"
+	"github.com/badimirzai/architon-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(newGraphCmd())
+}
+
+func newGraphCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "graph <path>",
+		Args:          cobra.ExactArgs(1),
+		Short:         "Emit stable GraphIR JSON for Studio and other tools",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Long: `Emit stable machine-readable architecture GraphIR.
+
+The graph command uses the same project detection, import, metadata,
+contract-enrichment, voltage-propagation, and deterministic rule pipeline as
+rv scan. It does not require Studio and does not call AI.
+
+Examples:
+  rv graph . --format json
+  rv graph . --format json --out graph.json
+  rv graph . --contracts examples/contracts/i2c_policy.yaml --format json --out graph.json
+  rv graph exports/example.net --meta .architon/meta.yaml --format json
+  rv graph . --bom bom/bom.csv --netlist exports/project.net --format json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mappingFile, _ := cmd.Flags().GetString("map")
+			bomOverride, _ := cmd.Flags().GetString("bom")
+			netlistOverride, _ := cmd.Flags().GetString("netlist")
+			metaOverride, _ := cmd.Flags().GetString("meta")
+			contractsOverride, _ := cmd.Flags().GetString("contracts")
+			outputFormat, _ := cmd.Flags().GetString("format")
+			outputPath, _ := cmd.Flags().GetString("out")
+			noKiCadCLI, _ := cmd.Flags().GetBool("no-kicad-cli")
+			kicadCLIPath, _ := cmd.Flags().GetString("kicad-cli")
+
+			outputFormat = strings.ToLower(strings.TrimSpace(outputFormat))
+			if outputFormat == "" {
+				outputFormat = "json"
+			}
+			if outputFormat != "json" {
+				return &ExitError{
+					Code: 3,
+					Err:  fmt.Errorf("unsupported output format %q (allowed: json)", outputFormat),
+				}
+			}
+
+			pipeline, err := runScanPipeline(args[0], scanPipelineOptions{
+				MappingFile:       mappingFile,
+				BOMOverride:       bomOverride,
+				NetlistOverride:   netlistOverride,
+				MetaOverride:      metaOverride,
+				ContractsOverride: contractsOverride,
+				NoKiCadCLI:        noKiCadCLI,
+				KiCadCLIPath:      kicadCLIPath,
+			})
+			if err != nil {
+				return err
+			}
+
+			graph := graphir.Build(graphir.BuildInput{
+				RVVersion:  version.Get().Version,
+				InputPath:  args[0],
+				Design:     pipeline.Design,
+				Report:     pipeline.Report,
+				ContractIR: pipeline.ContractIR,
+			})
+			data, err := graphir.RenderJSON(graph)
+			if err != nil {
+				return internalError(fmt.Errorf("marshal GraphIR JSON: %w", err))
+			}
+			if strings.TrimSpace(outputPath) != "" {
+				if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+					return &ExitError{
+						Code: 3,
+						Err:  fmt.Errorf("write graph JSON %s: %w", outputPath, err),
+					}
+				}
+			}
+			fmt.Fprint(cmd.OutOrStdout(), string(data))
+			return nil
+		},
+	}
+
+	cmd.Flags().String("map", "", "Path to YAML file with explicit BOM header mapping")
+	cmd.Flags().String("bom", "", "Override BOM file path when scanning a project directory")
+	cmd.Flags().String("netlist", "", "Override netlist file path when scanning a project directory")
+	cmd.Flags().String("meta", "", "Override meta file path (default: .architon/meta.yaml if present)")
+	cmd.Flags().String("contracts", "", "Override contracts file path (default: .architon/contracts.yaml if present)")
+	cmd.Flags().String("format", "json", "Output format: json")
+	cmd.Flags().String("out", "", "Path to write GraphIR JSON")
+	cmd.Flags().Bool("no-kicad-cli", false, "Disable automatic KiCad netlist generation for project directories")
+	cmd.Flags().String("kicad-cli", defaultKiCadCLI, "KiCad CLI binary name or path for automatic netlist generation")
+	return cmd
+}

--- a/cmd/graph_test.go
+++ b/cmd/graph_test.go
@@ -1,0 +1,577 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/badimirzai/architon-cli/internal/ui"
+)
+
+type graphCommandOutput struct {
+	GraphVersion  string                       `json:"graph_version"`
+	RVVersion     string                       `json:"rv_version"`
+	InputPath     string                       `json:"input_path"`
+	Summary       graphCommandSummary          `json:"summary"`
+	Nodes         []graphCommandNode           `json:"nodes"`
+	Edges         []graphCommandEdge           `json:"edges"`
+	Rails         []graphCommandRail           `json:"rails"`
+	Interfaces    []graphCommandInterface      `json:"interfaces"`
+	Findings      []graphCommandFinding        `json:"findings"`
+	FindingsIndex map[string]graphFindingLinks `json:"findings_index"`
+}
+
+type graphCommandSummary struct {
+	Violations int `json:"violations"`
+	Warnings   int `json:"warnings"`
+	Infos      int `json:"infos"`
+	Findings   int `json:"findings"`
+}
+
+type graphCommandNode struct {
+	ID               string   `json:"id"`
+	Ref              string   `json:"ref"`
+	Label            string   `json:"label"`
+	Type             string   `json:"type"`
+	ContractCoverage string   `json:"contract_coverage"`
+	Violations       int      `json:"violations"`
+	Warnings         int      `json:"warnings"`
+	FindingIDs       []string `json:"finding_ids"`
+	Nets             []string `json:"nets"`
+}
+
+type graphCommandEdge struct {
+	ID         string   `json:"id"`
+	Source     string   `json:"source"`
+	Target     string   `json:"target"`
+	Net        string   `json:"net"`
+	Type       string   `json:"type"`
+	Domain     string   `json:"domain"`
+	Interface  string   `json:"interface"`
+	VoltageV   *float64 `json:"voltage_v"`
+	Violations int      `json:"violations"`
+	Warnings   int      `json:"warnings"`
+	FindingIDs []string `json:"finding_ids"`
+}
+
+type graphCommandRail struct {
+	Name       string   `json:"name"`
+	VoltageV   *float64 `json:"voltage_v"`
+	SourceRef  string   `json:"source_ref"`
+	Consumers  []string `json:"consumers"`
+	Violations int      `json:"violations"`
+	Warnings   int      `json:"warnings"`
+	FindingIDs []string `json:"finding_ids"`
+}
+
+type graphCommandInterface struct {
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	Nets         []string               `json:"nets"`
+	Participants []string               `json:"participants"`
+	Pullups      []graphInterfacePullup `json:"pullups"`
+	Violations   int                    `json:"violations"`
+	Warnings     int                    `json:"warnings"`
+	FindingIDs   []string               `json:"finding_ids"`
+}
+
+type graphInterfacePullup struct {
+	Ref            string  `json:"ref"`
+	Net            string  `json:"net"`
+	ResistanceOhms float64 `json:"resistance_ohms"`
+	ToNet          string  `json:"to_net"`
+}
+
+type graphCommandFinding struct {
+	ID             string `json:"id"`
+	RuleID         string `json:"rule_id"`
+	ContractID     string `json:"contract_id"`
+	ContractSource string `json:"contract_source"`
+	Severity       string `json:"severity"`
+	Message        string `json:"message"`
+	ComponentRef   string `json:"component_ref"`
+	Net            string `json:"net"`
+	Pin            string `json:"pin"`
+	Requirement    string `json:"requirement"`
+	Fix            string `json:"fix"`
+	Provenance     string `json:"provenance"`
+}
+
+type graphFindingLinks struct {
+	NodeIDs      []string `json:"node_ids"`
+	EdgeIDs      []string `json:"edge_ids"`
+	RailNames    []string `json:"rail_names"`
+	InterfaceIDs []string `json:"interface_ids"`
+}
+
+func runGraphCommand(t *testing.T, cwd string, args ...string) (string, error) {
+	t.Helper()
+	ui.EnableColors(false)
+	t.Cleanup(func() {
+		ui.EnableColors(ui.DefaultColorEnabled())
+	})
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	cmd := newGraphCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return stdout.String(), err
+}
+
+func parseGraphOutput(t *testing.T, stdout string) graphCommandOutput {
+	t.Helper()
+	var graph graphCommandOutput
+	if err := json.Unmarshal([]byte(stdout), &graph); err != nil {
+		t.Fatalf("graph output is not valid JSON: %v\n%s", err, stdout)
+	}
+	return graph
+}
+
+func TestGraphCommand_JSONGraphRollupsAndDeterminism(t *testing.T) {
+	cwd := filepath.Dir(rootFixturePath(t, "esp32_overvoltage/netlist.net"))
+	netlist := filepath.Base(rootFixturePath(t, "esp32_overvoltage/netlist.net"))
+	meta := filepath.Base(rootFixturePath(t, "esp32_overvoltage/meta.yaml"))
+
+	stdout, err := runGraphCommand(t, cwd, netlist, "--meta", meta, "--format", "json")
+	if err != nil {
+		t.Fatalf("expected graph command to succeed, got %v\n%s", err, stdout)
+	}
+	graph := parseGraphOutput(t, stdout)
+	if graph.GraphVersion != "1" {
+		t.Fatalf("expected graph_version 1, got %q", graph.GraphVersion)
+	}
+	if graph.RVVersion == "" {
+		t.Fatalf("expected rv_version to be populated")
+	}
+	if graph.InputPath != netlist {
+		t.Fatalf("expected input_path %q, got %q", netlist, graph.InputPath)
+	}
+	if len(graph.Nodes) == 0 {
+		t.Fatalf("expected nodes to be generated")
+	}
+	if len(graph.Edges) == 0 {
+		t.Fatalf("expected edges to be generated")
+	}
+	if len(graph.Rails) == 0 {
+		t.Fatalf("expected rails to be generated")
+	}
+	if graph.Summary.Violations == 0 || graph.Summary.Findings == 0 {
+		t.Fatalf("expected graph summary to include finding counts, got %+v", graph.Summary)
+	}
+	if len(graph.Findings) == 0 {
+		t.Fatalf("expected graph findings to be embedded")
+	}
+
+	u1 := requireGraphNode(t, graph, "U1")
+	if u1.Type != "mcu" {
+		t.Fatalf("expected U1 to be classified as mcu, got %q", u1.Type)
+	}
+	if u1.ContractCoverage != "full" {
+		t.Fatalf("expected U1 full contract coverage, got %q", u1.ContractCoverage)
+	}
+	if u1.Violations == 0 {
+		t.Fatalf("expected U1 violation rollup")
+	}
+	if !containsString(u1.FindingIDs, "supply_abs_max") {
+		t.Fatalf("expected U1 finding_ids to include supply_abs_max, got %+v", u1.FindingIDs)
+	}
+
+	powerEdge := requireGraphEdgeByNet(t, graph, "/+5V")
+	if powerEdge.Type != "power" || powerEdge.Domain != "power" || powerEdge.Interface != "/+5V" {
+		t.Fatalf("unexpected power edge classification: %+v", powerEdge)
+	}
+	if powerEdge.VoltageV == nil || *powerEdge.VoltageV != 5 {
+		t.Fatalf("expected /+5V edge voltage 5V, got %+v", powerEdge.VoltageV)
+	}
+	if powerEdge.Violations == 0 || !containsString(powerEdge.FindingIDs, "supply_abs_max") {
+		t.Fatalf("expected power edge violation and finding link, got %+v", powerEdge)
+	}
+
+	rail := requireGraphRail(t, graph, "/+5V")
+	if rail.VoltageV == nil || *rail.VoltageV != 5 {
+		t.Fatalf("expected /+5V rail voltage 5V, got %+v", rail.VoltageV)
+	}
+	if rail.Violations == 0 || !containsString(rail.FindingIDs, "supply_abs_max") {
+		t.Fatalf("expected /+5V rail violation and finding link, got %+v", rail)
+	}
+
+	link, ok := graph.FindingsIndex["supply_abs_max"]
+	if !ok {
+		t.Fatalf("expected finding index entry for supply_abs_max")
+	}
+	if !containsString(link.NodeIDs, "U1") {
+		t.Fatalf("expected finding to link to U1, got %+v", link)
+	}
+	if !containsString(link.EdgeIDs, powerEdge.ID) {
+		t.Fatalf("expected finding to link to %s, got %+v", powerEdge.ID, link)
+	}
+	if !containsString(link.RailNames, "/+5V") {
+		t.Fatalf("expected finding to link to /+5V rail, got %+v", link)
+	}
+
+	stdoutAgain, err := runGraphCommand(t, cwd, netlist, "--meta", meta, "--format", "json")
+	if err != nil {
+		t.Fatalf("expected repeated graph command to succeed, got %v\n%s", err, stdoutAgain)
+	}
+	if stdoutAgain != stdout {
+		t.Fatalf("expected deterministic graph output across repeated runs\nfirst:\n%s\nsecond:\n%s", stdout, stdoutAgain)
+	}
+}
+
+func TestGraphCommand_IncludesSameScanFindings(t *testing.T) {
+	cwd := writeGraphPullupFixture(t, nil, false)
+
+	scanStdout, scanErr := runScanCommand(t, cwd, "design.net", "--contracts", "contracts.yaml", "--format", "json", "--out", "scan.json")
+	var exitErr *ExitError
+	if !errors.As(scanErr, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("expected scan violation exit 2, got err=%v stdout=%s", scanErr, scanStdout)
+	}
+	var scan scanCIOutput
+	if err := json.Unmarshal([]byte(scanStdout), &scan); err != nil {
+		t.Fatalf("scan output is not valid JSON: %v\n%s", err, scanStdout)
+	}
+	if scan.Summary.Violations == 0 || len(scan.Findings) == 0 {
+		t.Fatalf("expected scan pullup violations, got %+v", scan)
+	}
+
+	graphStdout, err := runGraphCommand(t, cwd, "design.net", "--contracts", "contracts.yaml", "--format", "json")
+	if err != nil {
+		t.Fatalf("expected graph command to succeed, got %v\n%s", err, graphStdout)
+	}
+	graph := parseGraphOutput(t, graphStdout)
+	if graph.Summary.Violations != scan.Summary.Violations || graph.Summary.Findings != len(scan.Findings) {
+		t.Fatalf("expected graph summary to mirror scan findings, scan=%+v graph=%+v", scan.Summary, graph.Summary)
+	}
+	for _, scanFinding := range scan.Findings {
+		if !graphHasFinding(t, graph, scanFinding.ID, scanFinding.RuleID, scanFinding.Message) {
+			t.Fatalf("expected graph findings to include scan finding id=%q rule=%q message=%q; graph findings=%+v", scanFinding.ID, scanFinding.RuleID, scanFinding.Message, graph.Findings)
+		}
+		if _, ok := graph.FindingsIndex[scanFinding.ID]; !ok {
+			t.Fatalf("expected findings_index to include scan finding id %q, got %+v", scanFinding.ID, graph.FindingsIndex)
+		}
+	}
+	if len(graph.FindingsIndex) == 0 {
+		t.Fatalf("expected findings_index to be populated")
+	}
+}
+
+func TestGraphCommand_PullupFindingRollups(t *testing.T) {
+	t.Run("no pullups", func(t *testing.T) {
+		graph := runPullupGraph(t, nil)
+		if graph.Summary.Violations == 0 {
+			t.Fatalf("expected no-pullup violations, got %+v", graph.Summary)
+		}
+		requireViolatingEdgeForNet(t, graph, "/I2C_SDA")
+		requireViolatingEdgeForNet(t, graph, "/I2C_SCL")
+		if iface := requireGraphInterface(t, graph, "I2C_MAIN"); iface.Violations == 0 {
+			t.Fatalf("expected I2C interface violation rollup, got %+v", iface)
+		}
+	})
+
+	t.Run("valid pullups", func(t *testing.T) {
+		graph := runPullupGraph(t, []graphResistor{
+			{Ref: "R1", Value: "4.7k", A: "/I2C_SDA", B: "/+3V3"},
+			{Ref: "R2", Value: "4.7k", A: "/I2C_SCL", B: "/+3V3"},
+		})
+		requireNoGraphViolations(t, graph)
+		if iface := requireGraphInterface(t, graph, "I2C_MAIN"); len(iface.Pullups) != 2 {
+			t.Fatalf("expected interface pullup metadata for valid pullups, got %+v", iface.Pullups)
+		}
+	})
+
+	t.Run("too strong pullups", func(t *testing.T) {
+		graph := runPullupGraph(t, []graphResistor{
+			{Ref: "R1", Value: "1k", A: "/I2C_SDA", B: "/+3V3"},
+			{Ref: "R2", Value: "1k", A: "/I2C_SCL", B: "/+3V3"},
+		})
+		requireViolatingNode(t, graph, "R1")
+		requireViolatingEdgeForNet(t, graph, "/I2C_SDA")
+		if iface := requireGraphInterface(t, graph, "I2C_MAIN"); iface.Violations == 0 {
+			t.Fatalf("expected I2C interface violation rollup, got %+v", iface)
+		}
+	})
+
+	t.Run("too weak pullups", func(t *testing.T) {
+		graph := runPullupGraph(t, []graphResistor{
+			{Ref: "R1", Value: "20k", A: "/I2C_SDA", B: "/+3V3"},
+			{Ref: "R2", Value: "20k", A: "/I2C_SCL", B: "/+3V3"},
+		})
+		requireViolatingNode(t, graph, "R1")
+		requireViolatingEdgeForNet(t, graph, "/I2C_SDA")
+		if iface := requireGraphInterface(t, graph, "I2C_MAIN"); iface.Violations == 0 {
+			t.Fatalf("expected I2C interface violation rollup, got %+v", iface)
+		}
+	})
+
+	t.Run("parallel pullups", func(t *testing.T) {
+		graph := runPullupGraph(t, []graphResistor{
+			{Ref: "R1", Value: "10k", A: "/I2C_SDA", B: "/+3V3"},
+			{Ref: "R2", Value: "10k", A: "/I2C_SCL", B: "/+3V3"},
+			{Ref: "R3", Value: "10k", A: "/I2C_SDA", B: "/+3V3"},
+			{Ref: "R4", Value: "10k", A: "/I2C_SCL", B: "/+3V3"},
+		})
+		requireNoGraphViolations(t, graph)
+	})
+
+	t.Run("pulldown", func(t *testing.T) {
+		graph := runPullupGraph(t, []graphResistor{
+			{Ref: "R1", Value: "4.7k", A: "/I2C_SDA", B: "GND"},
+			{Ref: "R2", Value: "4.7k", A: "/I2C_SCL", B: "GND"},
+		})
+		requireViolatingNode(t, graph, "R1")
+		requireViolatingEdgeForNet(t, graph, "/I2C_SDA")
+		if iface := requireGraphInterface(t, graph, "I2C_MAIN"); iface.Violations == 0 {
+			t.Fatalf("expected I2C interface violation rollup, got %+v", iface)
+		}
+	})
+}
+
+func TestGraphCommand_DefaultContractsAndOutFlag(t *testing.T) {
+	cwd := writeGraphPullupFixture(t, nil, true)
+
+	stdout, err := runGraphCommand(t, cwd, ".", "--format", "json", "--out", "graph.json")
+	if err != nil {
+		t.Fatalf("expected graph command with --out to succeed, got %v\n%s", err, stdout)
+	}
+	if strings.Contains(stdout, "\x1b[") {
+		t.Fatalf("expected JSON stdout without ANSI escapes, got %q", stdout)
+	}
+	stdoutGraph := parseGraphOutput(t, stdout)
+	if stdoutGraph.Summary.Violations == 0 || len(stdoutGraph.FindingsIndex) == 0 {
+		t.Fatalf("expected default .architon/contracts.yaml to be loaded, got %+v", stdoutGraph)
+	}
+	fileData, err := os.ReadFile(filepath.Join(cwd, "graph.json"))
+	if err != nil {
+		t.Fatalf("read graph out file: %v", err)
+	}
+	if strings.Contains(string(fileData), "\x1b[") {
+		t.Fatalf("expected JSON file without ANSI escapes, got %q", string(fileData))
+	}
+	fileGraph := parseGraphOutput(t, string(fileData))
+	if string(fileData) != stdout {
+		t.Fatalf("expected --out file to match stdout\nstdout:\n%s\nfile:\n%s", stdout, string(fileData))
+	}
+	if fileGraph.Summary != stdoutGraph.Summary {
+		t.Fatalf("expected stdout/file graph summaries to match, stdout=%+v file=%+v", stdoutGraph.Summary, fileGraph.Summary)
+	}
+}
+
+func TestGraphCommand_ContractsFlagOverridesArchitonContractsYAML(t *testing.T) {
+	cwd := writeGraphPullupFixture(t, nil, true)
+	writeScanTestFile(t, filepath.Join(cwd, "custom.yaml"), `contracts:
+  - id: address_policy
+    scope:
+      bus_type: i2c
+    require:
+      no_i2c_address_conflict: true
+    severity: error
+`)
+
+	stdout, err := runGraphCommand(t, cwd, ".", "--contracts", "custom.yaml", "--format", "json")
+	if err != nil {
+		t.Fatalf("expected graph command to succeed, got %v\n%s", err, stdout)
+	}
+	requireNoGraphViolations(t, parseGraphOutput(t, stdout))
+}
+
+func requireGraphNode(t *testing.T, graph graphCommandOutput, id string) graphCommandNode {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.ID == id {
+			return node
+		}
+	}
+	t.Fatalf("missing graph node %q in %+v", id, graph.Nodes)
+	return graphCommandNode{}
+}
+
+func requireGraphEdgeByNet(t *testing.T, graph graphCommandOutput, net string) graphCommandEdge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Net == net {
+			return edge
+		}
+	}
+	t.Fatalf("missing graph edge for net %q in %+v", net, graph.Edges)
+	return graphCommandEdge{}
+}
+
+func requireGraphRail(t *testing.T, graph graphCommandOutput, name string) graphCommandRail {
+	t.Helper()
+	for _, rail := range graph.Rails {
+		if rail.Name == name {
+			return rail
+		}
+	}
+	t.Fatalf("missing graph rail %q in %+v", name, graph.Rails)
+	return graphCommandRail{}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type graphResistor struct {
+	Ref   string
+	Value string
+	A     string
+	B     string
+}
+
+func runPullupGraph(t *testing.T, resistors []graphResistor) graphCommandOutput {
+	t.Helper()
+	cwd := writeGraphPullupFixture(t, resistors, false)
+	stdout, err := runGraphCommand(t, cwd, "design.net", "--contracts", "contracts.yaml", "--format", "json")
+	if err != nil {
+		t.Fatalf("expected graph command to succeed, got %v\n%s", err, stdout)
+	}
+	return parseGraphOutput(t, stdout)
+}
+
+func writeGraphPullupFixture(t *testing.T, resistors []graphResistor, defaultContracts bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeScanTestFile(t, filepath.Join(dir, "design.net"), graphPullupNetlist(resistors))
+	contractsPath := filepath.Join(dir, "contracts.yaml")
+	if defaultContracts {
+		contractsPath = filepath.Join(dir, ".architon", "contracts.yaml")
+	}
+	writeScanTestFile(t, contractsPath, graphPullupContracts())
+	return dir
+}
+
+func graphPullupContracts() string {
+	return `contracts:
+  - id: i2c_pullups
+    description: Ensure I2C pullups are between 2.2k and 10k.
+    scope:
+      bus_type: i2c
+      bus_id: i2c_main
+      nets:
+        sda: /I2C_SDA
+        scl: /I2C_SCL
+    require:
+      pullup_ohms:
+        min: 2200
+        max: 10000
+    severity: error
+`
+}
+
+func graphPullupNetlist(resistors []graphResistor) string {
+	components := strings.Builder{}
+	for _, resistor := range resistors {
+		components.WriteString(`    (comp (ref "` + resistor.Ref + `") (value "` + resistor.Value + `"))` + "\n")
+	}
+	netNodes := map[string][]string{
+		"/I2C_SDA": {
+			`      (node (ref "U1") (pin "1") (pinfunction "SDA"))`,
+			`      (node (ref "U2") (pin "1") (pinfunction "SDA"))`,
+		},
+		"/I2C_SCL": {
+			`      (node (ref "U1") (pin "2") (pinfunction "SCL"))`,
+			`      (node (ref "U2") (pin "2") (pinfunction "SCL"))`,
+		},
+		"GND": {
+			`      (node (ref "U1") (pin "3") (pinfunction "GND"))`,
+			`      (node (ref "U2") (pin "3") (pinfunction "GND"))`,
+		},
+		"/+3V3": {
+			`      (node (ref "U1") (pin "4") (pinfunction "VDD"))`,
+			`      (node (ref "U2") (pin "4") (pinfunction "VDD"))`,
+		},
+	}
+	for _, resistor := range resistors {
+		netNodes[resistor.A] = append(netNodes[resistor.A], `      (node (ref "`+resistor.Ref+`") (pin "1") (pinfunction "1"))`)
+		netNodes[resistor.B] = append(netNodes[resistor.B], `      (node (ref "`+resistor.Ref+`") (pin "2") (pinfunction "2"))`)
+	}
+	netNames := []string{"/I2C_SDA", "/I2C_SCL", "GND", "/+3V3"}
+	nets := strings.Builder{}
+	for i, netName := range netNames {
+		nets.WriteString(`    (net (code "` + string(rune('1'+i)) + `") (name "` + netName + `")` + "\n")
+		nets.WriteString(strings.Join(netNodes[netName], "\n"))
+		nets.WriteString(")\n")
+	}
+	return `(export (version "E")
+  (design (source "pullup_fixture.kicad_sch"))
+  (components
+    (comp (ref "U1") (value "MCU_A")
+      (fields (field (name "i2c_address") "0x10")))
+    (comp (ref "U2") (value "IMU_B")
+      (fields (field (name "i2c_address") "0x11")))
+` + components.String() + `  )
+  (libparts)
+  (nets
+` + nets.String() + `  ))
+`
+}
+
+func graphHasFinding(t *testing.T, graph graphCommandOutput, id string, ruleID string, message string) bool {
+	t.Helper()
+	for _, finding := range graph.Findings {
+		if finding.ID == id && finding.RuleID == ruleID && finding.Message == message {
+			return true
+		}
+	}
+	return false
+}
+
+func requireViolatingEdgeForNet(t *testing.T, graph graphCommandOutput, net string) graphCommandEdge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Net == net && edge.Violations > 0 && len(edge.FindingIDs) > 0 {
+			return edge
+		}
+	}
+	t.Fatalf("expected violating edge for net %s, got %+v", net, graph.Edges)
+	return graphCommandEdge{}
+}
+
+func requireViolatingNode(t *testing.T, graph graphCommandOutput, id string) graphCommandNode {
+	t.Helper()
+	node := requireGraphNode(t, graph, id)
+	if node.Violations == 0 {
+		t.Fatalf("expected node %s to have violation rollup, got %+v", id, node)
+	}
+	return node
+}
+
+func requireGraphInterface(t *testing.T, graph graphCommandOutput, id string) graphCommandInterface {
+	t.Helper()
+	for _, iface := range graph.Interfaces {
+		if iface.ID == id {
+			return iface
+		}
+	}
+	t.Fatalf("missing graph interface %q in %+v", id, graph.Interfaces)
+	return graphCommandInterface{}
+}
+
+func requireNoGraphViolations(t *testing.T, graph graphCommandOutput) {
+	t.Helper()
+	if graph.Summary.Violations != 0 || len(graph.FindingsIndex) != 0 || len(graph.Findings) != 0 {
+		t.Fatalf("expected no graph violations/findings, got summary=%+v findings=%+v index=%+v", graph.Summary, graph.Findings, graph.FindingsIndex)
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -35,6 +35,18 @@ components:
 
 Edit meta.yaml to define voltage sources and component limits.
 `
+	architonContractsYAML = `contracts:
+  - id: i2c_pullup_policy
+    description: Require I2C pull-ups to be present and within a sane default range.
+    scope:
+      bus_type: i2c
+    require:
+      common_ground: true
+      pullup_ohms:
+        min: 2200
+        max: 10000
+    severity: error
+`
 )
 
 var architonFiles = []architonFileTemplate{
@@ -92,7 +104,25 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().Bool("list", false, "List available templates")
 	cmd.Flags().Bool("force", false, "Overwrite output files if they already exist")
 
+	cmd.AddCommand(newInitContractsCmd())
 	return cmd
+}
+
+func newInitContractsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "contracts",
+		Short:         "Create .architon/contracts.yaml with starter policies",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := initializeArchitonContracts(); err != nil {
+				return fatalError(err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Wrote .architon/contracts.yaml")
+			return nil
+		},
+	}
 }
 
 func runTemplateInit(cmd *cobra.Command, list bool, templateName string) error {
@@ -155,6 +185,26 @@ func initializeArchitonProject(force bool) (initProjectResult, error) {
 	default:
 		return initProjectResult{}, fmt.Errorf("stat %s: %w", targetDir, err)
 	}
+}
+
+func initializeArchitonContracts() error {
+	targetDir := filepath.Clean(architonDirName)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", targetDir, err)
+	}
+	targetPath := filepath.Join(targetDir, "contracts.yaml")
+	if info, err := os.Stat(targetPath); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", targetPath)
+		}
+		return fmt.Errorf("%s already exists", targetPath)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", targetPath, err)
+	}
+	if err := os.WriteFile(targetPath, []byte(architonContractsYAML), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", targetPath, err)
+	}
+	return nil
 }
 
 func initializeNewArchitonProject(targetDir string) error {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -90,6 +90,21 @@ func TestInitFreshDirectoryCreatesArchitonProject(t *testing.T) {
 	}
 }
 
+func TestInitContractsCreatesStarterContractsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stdout, err := runInitCommand(t, tmpDir, "contracts")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(stdout, "Wrote .architon/contracts.yaml") {
+		t.Fatalf("expected contracts message, got %q", stdout)
+	}
+	if got := readArchitonFile(t, tmpDir, "contracts.yaml"); got != architonContractsYAML {
+		t.Fatalf("unexpected contracts.yaml contents:\n%s", got)
+	}
+}
+
 func TestInitRerunWithoutForceLeavesFilesUnchanged(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ var rootCmd = &cobra.Command{
 Quick help:
   rv check <file.yaml>       Run analysis
   rv scan <path>             Import KiCad BOM/netlist/schematic and emit DesignIR report JSON
+  rv graph <path>            Emit stable architecture GraphIR JSON
   rv contracts validate      Validate a custom contracts.yaml schema only
   rv parts list              List built-in deterministic contract parts
   rv init                    Initialize Architon metadata or write a starter robot spec

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -105,218 +105,29 @@ Examples:
 				}
 			}
 
-			resolvedInput, err := resolveScanInputWithOptions(args[0], bomOverride, netlistOverride, scanInputOptions{
-				AutoKiCadNetlist: !noKiCadCLI,
-				KiCadCLIPath:     kicadCLIPath,
+			pipeline, err := runScanPipeline(args[0], scanPipelineOptions{
+				MappingFile:       mappingFile,
+				BOMOverride:       bomOverride,
+				NetlistOverride:   netlistOverride,
+				MetaOverride:      metaOverride,
+				ContractsOverride: contractsOverride,
+				NoKiCadCLI:        noKiCadCLI,
+				KiCadCLIPath:      kicadCLIPath,
+				ShowAutoMetaHint:  outputFormat == "text",
+				HintWriter:        cmd.OutOrStdout(),
 			})
 			if err != nil {
-				return fatalError(err)
+				return err
 			}
 
-			design, err := importResolvedScanInput(resolvedInput, mappingFile)
-			if err != nil {
-				return userError(err)
-			}
-
-			// User contracts are loaded before report construction so invalid
-			// YAML is a tool error, not a partial scan result.
-			userContractsPath, userContracts, err := scanLoadUserContracts(resolvedInput, contractsOverride)
-			if err != nil {
-				return &ExitError{
-					Code: 3,
-					Err:  fmt.Errorf("contracts load failed: %w", err),
-				}
-			}
-
-			designReport := report.NewVerificationReport(design)
-			nameInferRes := infer.InferVoltagesFromNetNames(design)
-
-			// -------------------------
-			// META: auto-discover existing metadata only. Scan never writes
-			// .architon/meta.yaml; rv init owns file creation.
-			// -------------------------
-			metaPath := strings.TrimSpace(metaOverride)
-			metaExplicit := metaPath != ""
-
-			if resolvedInput.Directory {
-				defaultMetaPath := filepath.Join(resolvedInput.ProjectPath, ".architon", "meta.yaml")
-
-				if !metaExplicit {
-					// Auto-discover existing meta.yaml
-					if _, err := os.Stat(defaultMetaPath); err == nil {
-						metaPath = defaultMetaPath
-					} else if os.IsNotExist(err) {
-						metaPath = ""
-					} else {
-						return internalError(fmt.Errorf("stat default meta: %w", err))
-					}
-				} else {
-					// If user explicitly set --meta, respect it as-is
-					metaPath = filepath.Clean(metaPath)
-				}
-			}
-
-			// -------------------------
-			// META: load + decide whether to run rules
-			// -------------------------
-			metaObj := &meta.Meta{}
-			metaLoaded := false
-
-			if metaPath != "" {
-				// meta-based rules require nets
-				if designReport.Summary.Nets == 0 {
-					return &ExitError{
-						Code: 3,
-						Err:  errors.New("--meta requires a netlist (no nets present in DesignIR)"),
-					}
-				}
-
-				parsed, err := meta.Parse(metaPath)
-				if err != nil {
-					return &ExitError{
-						Code: 3,
-						Err:  fmt.Errorf("meta load failed: %w", err),
-					}
-				}
-
-				if metaExplicit {
-					// Explicit override: must be valid, otherwise tool failure
-					if err := meta.ValidateStrict(parsed); err != nil {
-						return &ExitError{
-							Code: 3,
-							Err:  fmt.Errorf("meta invalid: %w", err),
-						}
-					}
-					metaObj = parsed
-					metaLoaded = true
-				} else {
-					// Auto-discovered: use only completed entries, so skeleton placeholders stay informational.
-					prepared := scanPrepareAutoMeta(parsed)
-					if scanMetaHasEntries(prepared) {
-						if err := meta.ValidateStrict(prepared); err != nil {
-							return &ExitError{
-								Code: 3,
-								Err:  fmt.Errorf("meta invalid: %w", err),
-							}
-						}
-						metaObj = prepared
-						metaLoaded = true
-					} else if outputFormat == "text" {
-						fmt.Fprintf(cmd.OutOrStdout(), "Hint: edit .architon/meta.yaml (sources/components) to enable voltage rules\n")
-					}
-				}
-			}
-
-			// -------------------------
-			// VOLTAGE PROPAGATION + RULES
-			// -------------------------
-			initialVoltages := scanInitialVoltages(nameInferRes, metaObj)
-			propRes := propagate.Result{NetVoltages: map[string]propagate.NetVoltage{}}
-			if designReport.Summary.Nets > 0 && len(initialVoltages) > 0 {
-				propRes = propagate.Propagate(*design, *metaObj, initialVoltages)
-			}
-			// Build the report-facing inference after propagation so explicit
-			// metadata and regulator outputs can contribute provenance/confidence.
-			railInferRes := infer.InferVoltages(design, infer.VoltageInferenceOptions{
-				Evidence:  scanVoltageEvidence(propRes.NetVoltages),
-				Conflicts: propRes.Conflicts,
-			})
-
-			netVolts := scanReportNetVoltages(propRes.NetVoltages)
-			inferredNetVolts := scanReportInferredNetVoltages(nameInferRes)
-			unknownVoltageNets := scanReportUnknownVoltageNets(railInferRes)
-			railInferences := scanReportRailInferences(railInferRes)
-			railCoverage := rails.SummarizeRailCoverage(design, railInferRes.Inferences)
-			inferencesByNet := scanInferenceByNet(railInferRes.Inferences)
-			if designReport.Summary.Nets > 0 || len(netVolts) > 0 || len(inferredNetVolts) > 0 || len(unknownVoltageNets) > 0 || len(railInferences) > 0 || len(propRes.Conflicts) > 0 {
-				designReport.Derived = &report.Derived{
-					NetVoltages:         netVolts,
-					InferredNetVoltages: inferredNetVolts,
-					UnknownVoltageNets:  unknownVoltageNets,
-					RailInferences:      railInferences,
-					RailCoverage:        railCoverage,
-					Conflicts:           propRes.Conflicts,
-				}
-			}
-
-			if len(propRes.Conflicts) > 0 {
-				// Conflicts are violations (severity error => exit 2)
-				for _, c := range propRes.Conflicts {
-					result := report.RuleResult{
-						ID:       "RULE_VOLTAGE_CONFLICT",
-						RuleID:   "RULE_VOLTAGE_CONFLICT",
-						Severity: "ERROR",
-						Message:  c,
-						Source:   "voltage-propagation",
-						Provenance: &contracts.Provenance{
-							Source:   "voltage-propagation",
-							SourceID: "RULE_VOLTAGE_CONFLICT",
-							Detail:   "deterministic voltage propagation conflict",
-						},
-						Fix: "Resolve the conflicting voltage evidence for this net.",
-					}
-					if inference, ok := inferencesByNet[scanConflictNetName(c)]; ok {
-						result.Inference = scanReportInferenceProvenance(inference)
-					}
-					designReport.Rules = append(designReport.Rules, result)
-				}
-			}
-
-			// Contract enrichment is the boundary between imported design facts
-			// and rule-ready electrical intent. Rules below do not read meta.yaml,
-			// propagation structs, KiCad parser data, or file paths.
-			contractSources := []contracts.ContractSource{}
-			if metaLoaded {
-				contractSources = append(contractSources, enrichment.NewMetaYAMLSource(metaObj))
-			}
-			contractSources = append(contractSources,
-				contracts.FieldContractSource{},
-				contracts.NewBuiltinPartsSource(),
-			)
-			// Project contracts are appended as another ContractSource. From this
-			// point on the evaluator does not care whether a requirement came from
-			// built-ins, fields, meta.yaml, or user YAML.
-			if len(userContracts) > 0 {
-				contractSources = append(contractSources, contracts.NewUserYAMLSource(userContractsPath, userContracts))
-			}
-			contractSources = append(contractSources,
-				enrichment.NewNetVoltageSource("net-voltage-inference", scanContractNetVoltages(propRes.NetVoltages)),
-			)
-			contractIR, err := (enrichment.ContractEnricher{Sources: contractSources}).Enrich(design)
-			if err != nil {
-				return internalError(err)
-			}
-			coverage := contracts.SummarizeCoverage(design, contractIR)
-			designReport.ContractCoverage = &coverage
-			contractFindings := rules.CheckAll(design, contractIR, rules.DefaultRules())
-			designReport.Rules = append(designReport.Rules, scanReportRuleResults(contractFindings, inferencesByNet)...)
-			designReport.Rules = append(designReport.Rules, scanReportContractResults(contracts.Evaluate(design, contractIR), inferencesByNet)...)
-
-			if len(designReport.Rules) > 0 {
-				// Deterministic rule ordering
-				sort.SliceStable(designReport.Rules, func(i, j int) bool {
-					if designReport.Rules[i].ID == designReport.Rules[j].ID {
-						return designReport.Rules[i].Message < designReport.Rules[j].Message
-					}
-					return designReport.Rules[i].ID < designReport.Rules[j].ID
-				})
-			}
-			normalizeScanReportRules(designReport.Rules)
-			designReport.Findings = append([]report.RuleResult{}, designReport.Rules...)
-			// Update summary (because report.NewVerificationReport() computed these before rules existed)
-			designReport.Summary.Rules = len(designReport.Findings)
-			designReport.Summary.HasFailures = len(design.ParseErrors) > 0 || scanRuleViolationCount(designReport) > 0
-			designReport.Summary.PartsMatched = coverage.PartsMatched
-			designReport.Summary.UserContractsLoaded = len(userContracts)
-			designReport.Summary.BuiltInContractsLoaded = len(contracts.BuiltinContracts())
-			designReport.Summary.ActiveUserRequirements = scanActiveUserRequirements(contractIR)
-			designReport.Summary.AvailableContractRules = len(coverage.EnabledContractRules)
-			designReport.Summary.RequirementsEnabled = designReport.Summary.ActiveUserRequirements
-			designReport.Summary.PartContractCoveragePercentage = coverage.CoveragePercentage
-			designReport.Summary.ContractsApplied = coverage.ContractsApplied
-			designReport.Summary.ContractCoveragePercentage = coverage.CoveragePercentage
-			designReport.Summary.UnknownPowerCriticalRefs = coverage.UnknownPowerCriticalRefs
-			designReport.Summary.EnabledContractRules = coverage.EnabledContractRules
+			resolvedInput := pipeline.Input
+			design := pipeline.Design
+			designReport := pipeline.Report
+			nameInferRes := pipeline.NameInferResult
+			railInferRes := pipeline.RailInferResult
+			railInferences := pipeline.RailInferences
+			railCoverage := pipeline.RailCoverage
+			metaLoaded := pipeline.MetaLoaded
 
 			// Write report JSON after derived/rules are attached
 			if err := report.WriteVerificationReport(outputPath, designReport); err != nil {
@@ -439,6 +250,235 @@ Examples:
 	cmd.Flags().Bool("no-kicad-cli", false, "Disable automatic KiCad netlist generation for project directories")
 	cmd.Flags().String("kicad-cli", defaultKiCadCLI, "KiCad CLI binary name or path for automatic netlist generation")
 	return cmd
+}
+
+type scanPipelineOptions struct {
+	MappingFile       string
+	BOMOverride       string
+	NetlistOverride   string
+	MetaOverride      string
+	ContractsOverride string
+	NoKiCadCLI        bool
+	KiCadCLIPath      string
+	ShowAutoMetaHint  bool
+	HintWriter        io.Writer
+}
+
+type scanPipelineResult struct {
+	Input           resolvedScanInput
+	Design          *ir.DesignIR
+	Report          report.VerificationReport
+	ContractIR      *contracts.ContractIR
+	MetaLoaded      bool
+	NameInferResult infer.Result
+	RailInferResult infer.Result
+	RailInferences  []infer.VoltageInference
+	RailCoverage    rails.RailCoverageSummary
+}
+
+// runScanPipeline is the shared deterministic ingestion and rule pipeline used
+// by scan and graph. It deliberately stops before command-specific rendering.
+func runScanPipeline(inputPath string, opts scanPipelineOptions) (scanPipelineResult, error) {
+	resolvedInput, err := resolveScanInputWithOptions(inputPath, opts.BOMOverride, opts.NetlistOverride, scanInputOptions{
+		AutoKiCadNetlist: !opts.NoKiCadCLI,
+		KiCadCLIPath:     opts.KiCadCLIPath,
+	})
+	if err != nil {
+		return scanPipelineResult{}, fatalError(err)
+	}
+
+	design, err := importResolvedScanInput(resolvedInput, opts.MappingFile)
+	if err != nil {
+		return scanPipelineResult{}, userError(err)
+	}
+
+	// User contracts are loaded before report construction so invalid YAML is a
+	// tool error, not a partial scan or graph result.
+	userContractsPath, userContracts, err := scanLoadUserContracts(resolvedInput, opts.ContractsOverride)
+	if err != nil {
+		return scanPipelineResult{}, &ExitError{
+			Code: 3,
+			Err:  fmt.Errorf("contracts load failed: %w", err),
+		}
+	}
+
+	designReport := report.NewVerificationReport(design)
+	nameInferRes := infer.InferVoltagesFromNetNames(design)
+
+	// META: auto-discover existing metadata only. Scan/graph never writes
+	// .architon/meta.yaml; rv init owns file creation.
+	metaPath := strings.TrimSpace(opts.MetaOverride)
+	metaExplicit := metaPath != ""
+
+	if resolvedInput.Directory {
+		defaultMetaPath := filepath.Join(resolvedInput.ProjectPath, ".architon", "meta.yaml")
+
+		if !metaExplicit {
+			if _, err := os.Stat(defaultMetaPath); err == nil {
+				metaPath = defaultMetaPath
+			} else if os.IsNotExist(err) {
+				metaPath = ""
+			} else {
+				return scanPipelineResult{}, internalError(fmt.Errorf("stat default meta: %w", err))
+			}
+		} else {
+			metaPath = filepath.Clean(metaPath)
+		}
+	}
+
+	metaObj := &meta.Meta{}
+	metaLoaded := false
+
+	if metaPath != "" {
+		if designReport.Summary.Nets == 0 {
+			return scanPipelineResult{}, &ExitError{
+				Code: 3,
+				Err:  errors.New("--meta requires a netlist (no nets present in DesignIR)"),
+			}
+		}
+
+		parsed, err := meta.Parse(metaPath)
+		if err != nil {
+			return scanPipelineResult{}, &ExitError{
+				Code: 3,
+				Err:  fmt.Errorf("meta load failed: %w", err),
+			}
+		}
+
+		if metaExplicit {
+			if err := meta.ValidateStrict(parsed); err != nil {
+				return scanPipelineResult{}, &ExitError{
+					Code: 3,
+					Err:  fmt.Errorf("meta invalid: %w", err),
+				}
+			}
+			metaObj = parsed
+			metaLoaded = true
+		} else {
+			prepared := scanPrepareAutoMeta(parsed)
+			if scanMetaHasEntries(prepared) {
+				if err := meta.ValidateStrict(prepared); err != nil {
+					return scanPipelineResult{}, &ExitError{
+						Code: 3,
+						Err:  fmt.Errorf("meta invalid: %w", err),
+					}
+				}
+				metaObj = prepared
+				metaLoaded = true
+			} else if opts.ShowAutoMetaHint && opts.HintWriter != nil {
+				fmt.Fprintf(opts.HintWriter, "Hint: edit .architon/meta.yaml (sources/components) to enable voltage rules\n")
+			}
+		}
+	}
+
+	initialVoltages := scanInitialVoltages(nameInferRes, metaObj)
+	propRes := propagate.Result{NetVoltages: map[string]propagate.NetVoltage{}}
+	if designReport.Summary.Nets > 0 && len(initialVoltages) > 0 {
+		propRes = propagate.Propagate(*design, *metaObj, initialVoltages)
+	}
+	railInferRes := infer.InferVoltages(design, infer.VoltageInferenceOptions{
+		Evidence:  scanVoltageEvidence(propRes.NetVoltages),
+		Conflicts: propRes.Conflicts,
+	})
+
+	netVolts := scanReportNetVoltages(propRes.NetVoltages)
+	inferredNetVolts := scanReportInferredNetVoltages(nameInferRes)
+	unknownVoltageNets := scanReportUnknownVoltageNets(railInferRes)
+	railInferences := scanReportRailInferences(railInferRes)
+	railCoverage := rails.SummarizeRailCoverage(design, railInferRes.Inferences)
+	inferencesByNet := scanInferenceByNet(railInferRes.Inferences)
+	if designReport.Summary.Nets > 0 || len(netVolts) > 0 || len(inferredNetVolts) > 0 || len(unknownVoltageNets) > 0 || len(railInferences) > 0 || len(propRes.Conflicts) > 0 {
+		designReport.Derived = &report.Derived{
+			NetVoltages:         netVolts,
+			InferredNetVoltages: inferredNetVolts,
+			UnknownVoltageNets:  unknownVoltageNets,
+			RailInferences:      railInferences,
+			RailCoverage:        railCoverage,
+			Conflicts:           propRes.Conflicts,
+		}
+	}
+
+	if len(propRes.Conflicts) > 0 {
+		for _, c := range propRes.Conflicts {
+			result := report.RuleResult{
+				ID:       "RULE_VOLTAGE_CONFLICT",
+				RuleID:   "RULE_VOLTAGE_CONFLICT",
+				Severity: "ERROR",
+				Message:  c,
+				Source:   "voltage-propagation",
+				Provenance: &contracts.Provenance{
+					Source:   "voltage-propagation",
+					SourceID: "RULE_VOLTAGE_CONFLICT",
+					Detail:   "deterministic voltage propagation conflict",
+				},
+				Fix: "Resolve the conflicting voltage evidence for this net.",
+			}
+			if inference, ok := inferencesByNet[scanConflictNetName(c)]; ok {
+				result.Inference = scanReportInferenceProvenance(inference)
+			}
+			designReport.Rules = append(designReport.Rules, result)
+		}
+	}
+
+	contractSources := []contracts.ContractSource{}
+	if metaLoaded {
+		contractSources = append(contractSources, enrichment.NewMetaYAMLSource(metaObj))
+	}
+	contractSources = append(contractSources,
+		contracts.FieldContractSource{},
+		contracts.NewBuiltinPartsSource(),
+	)
+	if len(userContracts) > 0 {
+		contractSources = append(contractSources, contracts.NewUserYAMLSource(userContractsPath, userContracts))
+	}
+	contractSources = append(contractSources,
+		enrichment.NewNetVoltageSource("net-voltage-inference", scanContractNetVoltages(propRes.NetVoltages)),
+	)
+	contractIR, err := (enrichment.ContractEnricher{Sources: contractSources}).Enrich(design)
+	if err != nil {
+		return scanPipelineResult{}, internalError(err)
+	}
+	coverage := contracts.SummarizeCoverage(design, contractIR)
+	designReport.ContractCoverage = &coverage
+	contractFindings := rules.CheckAll(design, contractIR, rules.DefaultRules())
+	designReport.Rules = append(designReport.Rules, scanReportRuleResults(contractFindings, inferencesByNet)...)
+	designReport.Rules = append(designReport.Rules, scanReportContractResults(contracts.Evaluate(design, contractIR), inferencesByNet)...)
+
+	if len(designReport.Rules) > 0 {
+		sort.SliceStable(designReport.Rules, func(i, j int) bool {
+			if designReport.Rules[i].ID == designReport.Rules[j].ID {
+				return designReport.Rules[i].Message < designReport.Rules[j].Message
+			}
+			return designReport.Rules[i].ID < designReport.Rules[j].ID
+		})
+	}
+	normalizeScanReportRules(designReport.Rules)
+	designReport.Findings = append([]report.RuleResult{}, designReport.Rules...)
+	designReport.Summary.Rules = len(designReport.Findings)
+	designReport.Summary.HasFailures = len(design.ParseErrors) > 0 || scanRuleViolationCount(designReport) > 0
+	designReport.Summary.PartsMatched = coverage.PartsMatched
+	designReport.Summary.UserContractsLoaded = len(userContracts)
+	designReport.Summary.BuiltInContractsLoaded = len(contracts.BuiltinContracts())
+	designReport.Summary.ActiveUserRequirements = scanActiveUserRequirements(contractIR)
+	designReport.Summary.AvailableContractRules = len(coverage.EnabledContractRules)
+	designReport.Summary.RequirementsEnabled = designReport.Summary.ActiveUserRequirements
+	designReport.Summary.PartContractCoveragePercentage = coverage.CoveragePercentage
+	designReport.Summary.ContractsApplied = coverage.ContractsApplied
+	designReport.Summary.ContractCoveragePercentage = coverage.CoveragePercentage
+	designReport.Summary.UnknownPowerCriticalRefs = coverage.UnknownPowerCriticalRefs
+	designReport.Summary.EnabledContractRules = coverage.EnabledContractRules
+
+	return scanPipelineResult{
+		Input:           resolvedInput,
+		Design:          design,
+		Report:          designReport,
+		ContractIR:      contractIR,
+		MetaLoaded:      metaLoaded,
+		NameInferResult: nameInferRes,
+		RailInferResult: railInferRes,
+		RailInferences:  railInferences,
+		RailCoverage:    railCoverage,
+	}, nil
 }
 
 // importResolvedScanInput keeps CLI discovery separate from importer behavior.

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -943,6 +943,69 @@ func TestScan_WithoutContractsYAMLStillWorks(t *testing.T) {
 	}
 }
 
+func TestScan_DirectoryAutoLoadsArchitonContractsYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeScanTestFile(t, filepath.Join(tmpDir, "design.net"), graphPullupNetlist(nil))
+	writeScanTestFile(t, filepath.Join(tmpDir, ".architon", "contracts.yaml"), graphPullupContracts())
+
+	stdout, err := runScanCommand(t, tmpDir, ".", "--format", "json", "--out", "scan.json")
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("expected auto-loaded contract violation exit 2, got err=%v stdout=%s", err, stdout)
+	}
+	var scan scanCIOutput
+	if err := json.Unmarshal([]byte(stdout), &scan); err != nil {
+		t.Fatalf("scan output is not valid JSON: %v\n%s", err, stdout)
+	}
+	if scan.Summary.UserContractsLoaded != 1 || scan.Summary.Violations == 0 || len(scan.Findings) == 0 {
+		t.Fatalf("expected .architon/contracts.yaml findings, got %+v", scan)
+	}
+}
+
+func TestScan_ContractsFlagOverridesArchitonContractsYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeScanTestFile(t, filepath.Join(tmpDir, "design.net"), graphPullupNetlist(nil))
+	writeScanTestFile(t, filepath.Join(tmpDir, ".architon", "contracts.yaml"), graphPullupContracts())
+	writeScanTestFile(t, filepath.Join(tmpDir, "custom.yaml"), `contracts:
+  - id: address_policy
+    scope:
+      bus_type: i2c
+    require:
+      no_i2c_address_conflict: true
+    severity: error
+`)
+
+	stdout, err := runScanCommand(t, tmpDir, ".", "--contracts", "custom.yaml", "--format", "json", "--out", "scan.json")
+	if err != nil {
+		t.Fatalf("expected custom contracts override to scan cleanly, got %v\n%s", err, stdout)
+	}
+	var scan scanCIOutput
+	if err := json.Unmarshal([]byte(stdout), &scan); err != nil {
+		t.Fatalf("scan output is not valid JSON: %v\n%s", err, stdout)
+	}
+	if scan.Summary.UserContractsLoaded != 1 || scan.Summary.Violations != 0 || len(scan.Findings) != 0 {
+		t.Fatalf("expected custom contracts to override default .architon contract, got %+v", scan)
+	}
+}
+
+func TestScan_DirectoryWithoutArchitonContractsYAMLIgnoresRootContractsYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeScanTestFile(t, filepath.Join(tmpDir, "design.net"), graphPullupNetlist(nil))
+	writeScanTestFile(t, filepath.Join(tmpDir, "contracts.yaml"), graphPullupContracts())
+
+	stdout, err := runScanCommand(t, tmpDir, ".", "--format", "json", "--out", "scan.json")
+	if err != nil {
+		t.Fatalf("expected scan without .architon/contracts.yaml to ignore root contracts.yaml, got %v\n%s", err, stdout)
+	}
+	var scan scanCIOutput
+	if err := json.Unmarshal([]byte(stdout), &scan); err != nil {
+		t.Fatalf("scan output is not valid JSON: %v\n%s", err, stdout)
+	}
+	if scan.Summary.UserContractsLoaded != 0 || scan.Summary.Violations != 0 || len(scan.Findings) != 0 {
+		t.Fatalf("expected no auto-loaded root contracts or findings, got %+v", scan)
+	}
+}
+
 func TestScan_UserYAMLContractFindingProvenance(t *testing.T) {
 	tmpDir := t.TempDir()
 	netlistPath := filepath.Join(tmpDir, "i2c.net")

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -3,12 +3,14 @@
 
 `rv check` validates system architecture from a YAML specification.
 `rv scan` imports KiCad BOM/netlist data and generates a normalized DesignIR report.
+`rv graph` emits stable GraphIR JSON for Studio and other renderers.
 
 Core commands:
 
 ```text
 rv check <file.yaml>          Run deterministic analysis
 rv scan <path>                Import BOM CSV, KiCad .net, or project directory and emit DesignIR report JSON
+rv graph <path>               Emit stable architecture GraphIR JSON
 rv contracts validate <path>  Validate a custom contracts.yaml schema only
 rv parts list                 List built-in deterministic contract parts
 rv parts show <mpn>           Show one built-in contract part
@@ -16,6 +18,9 @@ rv init                       Create .architon metadata or write a starter robot
 rv version                    Show installed version
 rv check --output json        Emit JSON findings to stdout
 rv scan . --format json       Emit stable scan JSON to stdout
+rv graph . --format json      Emit stable GraphIR JSON to stdout
+rv graph . --format json --out graph.json
+                              Emit GraphIR JSON to stdout and graph.json
 rv scan . --format markdown   Emit PR-comment-ready Markdown
 rv scan . --format github     Emit GitHub Actions annotations
 rv --help                     Show all commands and flags
@@ -38,6 +43,8 @@ rv check specs/robot.yaml --output json --pretty
 rv scan examples/bom/bom.csv
 rv scan examples/bom/bom.csv --map examples/mapping.yaml
 rv scan exports/project.net --meta .architon/meta.yaml --rails
+rv graph exports/project.net --meta .architon/meta.yaml --format json
+rv graph . --contracts examples/contracts/i2c_policy.yaml --format json --out graph.json
 rv scan . --contracts i2c_pullup_policy.yaml --verbose
 rv scan . --format github
 rv parts list
@@ -50,6 +57,6 @@ Contracts come from built-in component data, project metadata, schematic/BOM fie
 
 Use `--verbose` or `--rails` to inspect rail inference, confidence, and voltage coverage. See [docs/rail-inference.md](docs/rail-inference.md).
 
-Architon writes deterministic JSON reports for CI and tooling. Default scan output is `architon-report.json`. See [docs/report-format.md](docs/report-format.md) and [docs/ci.md](docs/ci.md).
+Architon writes deterministic JSON reports for CI and tooling. Default scan output is `architon-report.json`. See [docs/report-format.md](docs/report-format.md), [docs/graph-ir.md](docs/graph-ir.md), and [docs/ci.md](docs/ci.md).
 
 YAML architecture specs and part lookup behavior are documented in [docs/spec.md](docs/spec.md).

--- a/docs/graph-ir.md
+++ b/docs/graph-ir.md
@@ -1,0 +1,359 @@
+# GraphIR
+
+GraphIR is the stable machine-readable architecture graph emitted by:
+
+```bash
+rv graph <path> --format json
+rv graph <path> --format json --out graph.json
+rv graph <path> --contracts .architon/contracts.yaml --format json
+```
+
+`rv graph` uses the same project detection, import, metadata, contract loading,
+voltage propagation, and deterministic rule evaluation pipeline as `rv scan`.
+It does not require Studio and does not call AI.
+
+GraphIR is for Studio and other graph renderers. It is not a replacement for
+the scan report: the scan report remains the primary CI/reporting artifact,
+while GraphIR embeds the same findings so renderers can highlight affected
+graph elements directly.
+
+## Schema
+
+Top-level object:
+
+```json
+{
+  "graph_version": "1",
+  "rv_version": "v0.6.0-dev",
+  "input_path": "project-or-file-path",
+  "summary": {
+    "violations": 0,
+    "warnings": 0,
+    "infos": 0,
+    "findings": 0
+  },
+  "nodes": [],
+  "edges": [],
+  "rails": [],
+  "interfaces": [],
+  "findings": [],
+  "findings_index": {}
+}
+```
+
+`summary` counts embedded scan findings by severity. `ERROR` increments
+`violations`, `WARN` increments `warnings`, and `INFO` increments `infos`.
+
+### Nodes
+
+Nodes are physical components from the imported design.
+
+```json
+{
+  "id": "U1",
+  "ref": "U1",
+  "label": "U1 ESP32-WROOM-32",
+  "type": "mcu",
+  "contract_coverage": "full",
+  "violations": 0,
+  "warnings": 0,
+  "nets": ["/I2C_SDA", "+3V3"],
+  "metadata": {
+    "value": "ESP32-WROOM-32",
+    "footprint": "RF_Module:ESP32-WROOM-32",
+    "mpn": "ESP32-WROOM-32",
+    "manufacturer": "Espressif"
+  }
+}
+```
+
+Node `type` is one of:
+
+```text
+mcu, sensor, motor_driver, regulator, connector, passive, power_source, unknown
+```
+
+`contract_coverage` is one of:
+
+```text
+full, partial, missing, unknown
+```
+
+### Edges
+
+Edges are electrical relationships between components on shared nets. In
+GraphIR v1 these are pairwise component-to-component edges, sorted by stable
+edge ID. Renderers may group them by `interface`, `type`, `domain`, or `net` to
+avoid visual clutter.
+
+```json
+{
+  "id": "edge_U1_U2_I2C_SDA",
+  "source": "U1",
+  "target": "U2",
+  "net": "/I2C_SDA",
+  "type": "i2c",
+  "domain": "data",
+  "interface": "I2C_1",
+  "voltage_v": 3.3,
+  "violations": 0,
+  "warnings": 0,
+  "finding_ids": []
+}
+```
+
+Edge `type` is one of:
+
+```text
+power, i2c, spi, uart, gpio, analog, motor, unknown
+```
+
+Edge `domain` is one of:
+
+```text
+power, data, control, unknown
+```
+
+`voltage_v` is omitted when no deterministic voltage is known for the net.
+`interface` is always present. For power edges it is the rail/net name; for
+unknown edges it is `"unknown"`.
+
+### Rails
+
+Rails are power domains inferred from net names, pin roles, metadata, and
+voltage propagation.
+
+```json
+{
+  "name": "/+3V3",
+  "voltage_v": 3.3,
+  "source_ref": "U2",
+  "consumers": ["U1", "U3"],
+  "violations": 0,
+  "warnings": 0,
+  "finding_ids": []
+}
+```
+
+`voltage_v` is emitted for explicit, propagated, or inferred rails. `source_ref`
+is the best deterministic source component when one is known, otherwise an empty
+string.
+
+### Interfaces
+
+Interfaces group bus-like electrical relationships such as I2C, SPI, and UART.
+They are intended for Studio-level rendering when pairwise edges would be too
+dense.
+
+```json
+{
+  "id": "I2C_1",
+  "type": "i2c",
+  "nets": ["/I2C_SCL", "/I2C_SDA"],
+  "participants": ["U1", "U2"],
+  "pullups": [
+    {
+      "ref": "R1",
+      "net": "/I2C_SDA",
+      "resistance_ohms": 4700,
+      "to_net": "/+3V3"
+    }
+  ],
+  "violations": 0,
+  "warnings": 0,
+  "finding_ids": []
+}
+```
+
+`pullups` is deterministic topology metadata. GraphIR does not invent pull-up
+findings; it only embeds and links findings produced by the scan pipeline.
+
+### Findings
+
+Findings are the same deterministic scan findings produced by `rv scan`, with
+stable IDs assigned for graph linking.
+
+```json
+{
+  "id": "pullup_ohms_01",
+  "rule_id": "pullup_ohms",
+  "contract_id": "i2c_pullups",
+  "contract_source": "user_yaml",
+  "severity": "ERROR",
+  "message": "Net /I2C_SDA has no pull-up resistor in scope",
+  "component_ref": "",
+  "net": "/I2C_SDA",
+  "pin": "",
+  "requirement": "pullup_ohms",
+  "fix": "Add a pull-up resistor from /I2C_SDA to the I2C rail between 2200 and 10000 ohms.",
+  "provenance": "source=user_yaml; source_id=i2c_pullups"
+}
+```
+
+Severity is one of `ERROR`, `WARN`, or `INFO`.
+
+### Findings Index
+
+`findings_index` maps each finding ID to the graph elements affected by that
+finding.
+
+```json
+{
+  "pullup_ohms_01": {
+    "node_ids": ["R1"],
+    "edge_ids": ["edge_R1_U1_I2C_SDA", "edge_R1_U2_I2C_SDA"],
+    "rail_names": [],
+    "interface_ids": ["I2C_1"]
+  }
+}
+```
+
+Rollup rules:
+
+- If a finding has `component_ref`, it attaches to the matching node.
+- If a finding has `net`, it attaches to all graph edges for that net.
+- If a finding net is a rail, it attaches to the matching rail.
+- If a finding mentions multiple nets, each matching edge or rail can be linked.
+- Bus-level findings attach to matching interface objects and relevant bus edges.
+- `ERROR` increments `violations`; `WARN` increments `warnings`; `INFO` only
+  adds finding links.
+
+Finding IDs are stable within one graph. When multiple report findings share the
+same rule ID, GraphIR appends deterministic numeric suffixes such as
+`pullup_ohms_01`.
+
+## Example
+
+```json
+{
+  "graph_version": "1",
+  "rv_version": "v0.6.0-dev",
+  "input_path": "examples/custom-contracts/exports/custom_contracts.net",
+  "summary": {
+    "violations": 1,
+    "warnings": 0,
+    "infos": 0,
+    "findings": 1
+  },
+  "nodes": [
+    {
+      "id": "U1",
+      "ref": "U1",
+      "label": "U1 MCU_A",
+      "type": "mcu",
+      "contract_coverage": "partial",
+      "violations": 0,
+      "warnings": 0,
+      "nets": ["/+3V3", "/I2C_SDA", "GND"],
+      "metadata": {
+        "value": "MCU_A",
+        "footprint": "",
+        "mpn": "MCU_A",
+        "manufacturer": ""
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge_U1_U2_I2C_SDA",
+      "source": "U1",
+      "target": "U2",
+      "net": "/I2C_SDA",
+      "type": "i2c",
+      "domain": "data",
+      "interface": "I2C_MAIN",
+      "voltage_v": 3.3,
+      "violations": 1,
+      "warnings": 0,
+      "finding_ids": ["pullup_ohms_01"]
+    }
+  ],
+  "rails": [
+    {
+      "name": "/+3V3",
+      "voltage_v": 3.3,
+      "source_ref": "",
+      "consumers": ["U1", "U2"],
+      "violations": 0,
+      "warnings": 0,
+      "finding_ids": []
+    }
+  ],
+  "interfaces": [
+    {
+      "id": "I2C_MAIN",
+      "type": "i2c",
+      "nets": ["/I2C_SCL", "/I2C_SDA"],
+      "participants": ["U1", "U2"],
+      "pullups": [],
+      "violations": 1,
+      "warnings": 0,
+      "finding_ids": ["pullup_ohms_01"]
+    }
+  ],
+  "findings": [
+    {
+      "id": "pullup_ohms_01",
+      "rule_id": "pullup_ohms",
+      "contract_id": "i2c_pullups",
+      "contract_source": "user_yaml",
+      "severity": "ERROR",
+      "message": "Net /I2C_SDA has no pull-up resistor in scope",
+      "component_ref": "",
+      "net": "/I2C_SDA",
+      "pin": "",
+      "requirement": "pullup_ohms",
+      "fix": "Add a pull-up resistor from /I2C_SDA to the I2C rail between 2200 and 10000 ohms.",
+      "provenance": "source=user_yaml; source_id=i2c_pullups"
+    }
+  ],
+  "findings_index": {
+    "pullup_ohms_01": {
+      "node_ids": [],
+      "edge_ids": ["edge_U1_U2_I2C_SDA"],
+      "rail_names": [],
+      "interface_ids": ["I2C_MAIN"]
+    }
+  }
+}
+```
+
+## Studio Consumption
+
+Studio should treat `nodes`, `edges`, `rails`, and `interfaces` as renderable
+graph data:
+
+- Use `node.id` as the graph node key and `node.ref` as the schematic reference.
+- Use `edge.source` and `edge.target` to connect physical components.
+- Use `edge.net` as the electrical net represented by an edge.
+- Group or style edges by `edge.interface`, `edge.type`, and `edge.domain`.
+- Prefer `interfaces` for bus rendering when pairwise edges would be visually
+  dense.
+- Render rails from `rails`; rails may also appear as power edges when connected
+  components share a rail net.
+- Use `violations` and `warnings` on nodes, edges, rails, and interfaces for
+  badges.
+- Use `findings` for finding detail panels.
+- Use `finding_ids` and `findings_index` to highlight all graph elements
+  affected by a selected finding.
+
+Studio should not parse human scan output and should not infer additional
+electrical meaning from labels. The stable fields are the typed fields above.
+
+## Stability
+
+GraphIR `graph_version` is currently `"1"`. For a given CLI build, input files,
+metadata, contracts, and command flags, output is deterministic across repeated
+runs.
+
+GraphIR v1 preserves stable ordering:
+
+- nodes sort by component reference
+- edges sort by edge ID
+- rails sort by rail name
+- interfaces sort by interface ID
+- findings preserve canonical scan finding order
+
+Additive fields may appear in future `graph_version` `"1"` outputs. Existing
+fields, enum values, and link semantics will not be removed or redefined without
+incrementing `graph_version`.

--- a/internal/contracts/evaluator_system.go
+++ b/internal/contracts/evaluator_system.go
@@ -92,6 +92,11 @@ func evaluatePullupOhms(design *ir.DesignIR, contractIR *ContractIR, req Applied
 			finding.Net = signalNet.Net.Name
 			attachI2CBusToFinding(&finding, signalNet.BusID, signalNet.BusNets)
 			attachPullupBoundsToFinding(&finding, req)
+			invalidPullups := invalidPullupCandidatesForSignalNet(design, contractIR, signalNet.Net.Name, req.Scope)
+			if len(invalidPullups) > 0 {
+				finding.ComponentRef = invalidPullups[0].Ref
+				finding.PullupResistors = pullupRefs(invalidPullups)
+			}
 			findings = append(findings, finding)
 			continue
 		}
@@ -573,6 +578,50 @@ func pullupsForSignalNet(design *ir.DesignIR, contractIR *ContractIR, signalNet 
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Ref < out[j].Ref })
 	return out
+}
+
+// invalidPullupCandidatesForSignalNet finds resistor-like parts that touch an
+// I2C signal but do not qualify as pull-ups. This keeps scan provenance on
+// pulldowns and SDA-to-SCL resistors without changing the finding itself.
+func invalidPullupCandidatesForSignalNet(design *ir.DesignIR, contractIR *ContractIR, signalNet string, scope ContractScope) []pullupCandidate {
+	connected := componentConnections(design)
+	parts := partIndex(design)
+	out := make([]pullupCandidate, 0)
+	for ref, nets := range connected {
+		part := parts[ref]
+		if !looksLikeResistor(part) {
+			continue
+		}
+		if len(nets) < 2 || !componentConnectedToNet(nets, signalNet) {
+			continue
+		}
+		ohms := pullupOhms(part)
+		if ohms <= 0 {
+			continue
+		}
+		for _, conn := range nets {
+			if conn.Net == signalNet {
+				continue
+			}
+			if isValidPullupTarget(contractIR, conn.Net, scope) {
+				continue
+			}
+			out = append(out, pullupCandidate{Ref: ref, Ohms: ohms, RailNet: conn.Net, SignalNet: signalNet})
+			break
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Ref < out[j].Ref })
+	return out
+}
+
+func isValidPullupTarget(contractIR *ContractIR, netName string, scope ContractScope) bool {
+	if isGroundNetName(netName) {
+		return false
+	}
+	if scope.Rail != "" && netName != scope.Rail {
+		return false
+	}
+	return isPositiveSupplyNet(contractIR, netName)
 }
 
 // effectivePullupOhms combines parallel pull-up resistors.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1,0 +1,1504 @@
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/badimirzai/architon-cli/internal/contracts"
+	"github.com/badimirzai/architon-cli/internal/infer"
+	"github.com/badimirzai/architon-cli/internal/ir"
+	"github.com/badimirzai/architon-cli/internal/report"
+)
+
+const SchemaVersion = "1"
+
+type GraphIR struct {
+	GraphVersion  string                 `json:"graph_version"`
+	RVVersion     string                 `json:"rv_version"`
+	InputPath     string                 `json:"input_path"`
+	Summary       Summary                `json:"summary"`
+	Nodes         []Node                 `json:"nodes"`
+	Edges         []Edge                 `json:"edges"`
+	Rails         []Rail                 `json:"rails"`
+	Interfaces    []Interface            `json:"interfaces"`
+	Findings      []Finding              `json:"findings"`
+	FindingsIndex map[string]FindingLink `json:"findings_index"`
+}
+
+type Summary struct {
+	Violations int `json:"violations"`
+	Warnings   int `json:"warnings"`
+	Infos      int `json:"infos"`
+	Findings   int `json:"findings"`
+}
+
+type Node struct {
+	ID               string       `json:"id"`
+	Ref              string       `json:"ref"`
+	Label            string       `json:"label"`
+	Type             string       `json:"type"`
+	ContractCoverage string       `json:"contract_coverage"`
+	Violations       int          `json:"violations"`
+	Warnings         int          `json:"warnings"`
+	FindingIDs       []string     `json:"finding_ids"`
+	Nets             []string     `json:"nets"`
+	Metadata         NodeMetadata `json:"metadata"`
+}
+
+type NodeMetadata struct {
+	Value        string `json:"value"`
+	Footprint    string `json:"footprint"`
+	MPN          string `json:"mpn"`
+	Manufacturer string `json:"manufacturer"`
+}
+
+type Edge struct {
+	ID         string   `json:"id"`
+	Source     string   `json:"source"`
+	Target     string   `json:"target"`
+	Net        string   `json:"net"`
+	Type       string   `json:"type"`
+	Domain     string   `json:"domain"`
+	Interface  string   `json:"interface"`
+	VoltageV   *float64 `json:"voltage_v,omitempty"`
+	Violations int      `json:"violations"`
+	Warnings   int      `json:"warnings"`
+	FindingIDs []string `json:"finding_ids"`
+}
+
+type Rail struct {
+	Name       string   `json:"name"`
+	VoltageV   *float64 `json:"voltage_v,omitempty"`
+	SourceRef  string   `json:"source_ref"`
+	Consumers  []string `json:"consumers"`
+	Violations int      `json:"violations"`
+	Warnings   int      `json:"warnings"`
+	FindingIDs []string `json:"finding_ids"`
+}
+
+type Interface struct {
+	ID           string            `json:"id"`
+	Type         string            `json:"type"`
+	Nets         []string          `json:"nets"`
+	Participants []string          `json:"participants"`
+	Pullups      []InterfacePullup `json:"pullups"`
+	Violations   int               `json:"violations"`
+	Warnings     int               `json:"warnings"`
+	FindingIDs   []string          `json:"finding_ids"`
+}
+
+type InterfacePullup struct {
+	Ref            string  `json:"ref"`
+	Net            string  `json:"net"`
+	ResistanceOhms float64 `json:"resistance_ohms"`
+	ToNet          string  `json:"to_net"`
+}
+
+type Finding struct {
+	ID             string `json:"id"`
+	RuleID         string `json:"rule_id"`
+	ContractID     string `json:"contract_id"`
+	ContractSource string `json:"contract_source"`
+	Severity       string `json:"severity"`
+	Message        string `json:"message"`
+	ComponentRef   string `json:"component_ref"`
+	Net            string `json:"net"`
+	Pin            string `json:"pin"`
+	Requirement    string `json:"requirement"`
+	Fix            string `json:"fix"`
+	Provenance     string `json:"provenance"`
+}
+
+type FindingLink struct {
+	NodeIDs      []string `json:"node_ids"`
+	EdgeIDs      []string `json:"edge_ids"`
+	RailNames    []string `json:"rail_names"`
+	InterfaceIDs []string `json:"interface_ids,omitempty"`
+}
+
+type BuildInput struct {
+	RVVersion  string
+	InputPath  string
+	Design     *ir.DesignIR
+	Report     report.VerificationReport
+	ContractIR *contracts.ContractIR
+}
+
+type builder struct {
+	input          BuildInput
+	design         *ir.DesignIR
+	partByRef      map[string]ir.Part
+	netByName      map[string]ir.Net
+	netsByRef      map[string][]string
+	pinsByRef      map[string][]ir.PinRef
+	voltageByNet   map[string]float64
+	voltageSource  map[string]string
+	interfaceByNet map[string]string
+	findings       []findingRecord
+	nodes          []Node
+	edges          []Edge
+	rails          []Rail
+	interfaces     []Interface
+	nodeIndex      map[string]int
+	edgeIndex      map[string]int
+	railIndex      map[string]int
+	interfaceIndex map[string]int
+}
+
+type netClass struct {
+	Type      string
+	Domain    string
+	Interface string
+}
+
+type netGroup struct {
+	net string
+	key string
+}
+
+type findingRecord struct {
+	id      string
+	raw     report.RuleResult
+	finding Finding
+}
+
+func Build(input BuildInput) GraphIR {
+	design := input.Design
+	if design == nil {
+		design = &ir.DesignIR{Version: ir.SchemaVersion}
+	}
+	b := &builder{
+		input:          input,
+		design:         design,
+		partByRef:      map[string]ir.Part{},
+		netByName:      map[string]ir.Net{},
+		netsByRef:      map[string][]string{},
+		pinsByRef:      map[string][]ir.PinRef{},
+		voltageByNet:   map[string]float64{},
+		voltageSource:  map[string]string{},
+		interfaceByNet: map[string]string{},
+		nodeIndex:      map[string]int{},
+		edgeIndex:      map[string]int{},
+		railIndex:      map[string]int{},
+		interfaceIndex: map[string]int{},
+	}
+	b.indexDesign()
+	b.indexVoltages()
+	b.interfaceByNet = buildInterfaceIndex(design, input.ContractIR, input.Report)
+	b.findings = buildFindingRecords(input.Report)
+	b.nodes = b.buildNodes()
+	b.edges = b.buildEdges()
+	b.rails = b.buildRails()
+	b.interfaces = b.buildInterfaces()
+	findingsIndex := b.attachFindings()
+	findings := b.graphFindings()
+
+	return GraphIR{
+		GraphVersion:  SchemaVersion,
+		RVVersion:     strings.TrimSpace(input.RVVersion),
+		InputPath:     input.InputPath,
+		Summary:       summarizeFindings(findings),
+		Nodes:         b.nodes,
+		Edges:         b.edges,
+		Rails:         b.rails,
+		Interfaces:    b.interfaces,
+		Findings:      findings,
+		FindingsIndex: findingsIndex,
+	}
+}
+
+func RenderJSON(graph GraphIR) ([]byte, error) {
+	data, err := json.MarshalIndent(graph, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func buildFindingRecords(result report.VerificationReport) []findingRecord {
+	result = report.CanonicalizeVerificationReport(result)
+	out := make([]findingRecord, 0, len(result.Findings))
+	for _, finding := range result.Findings {
+		id := strings.TrimSpace(finding.ID)
+		if id == "" {
+			id = sanitizeIDPart(firstNonEmpty(finding.RuleID, "finding"))
+		}
+		out = append(out, findingRecord{
+			id:      id,
+			raw:     finding,
+			finding: buildGraphFinding(id, finding),
+		})
+	}
+	return out
+}
+
+func buildGraphFinding(id string, finding report.RuleResult) Finding {
+	ruleID := strings.TrimSpace(finding.RuleID)
+	if ruleID == "" {
+		ruleID = strings.TrimSpace(finding.ID)
+	}
+	if ruleID == "" {
+		ruleID = id
+	}
+
+	componentRef := strings.TrimSpace(finding.ComponentRef)
+	if componentRef == "" {
+		componentRef = strings.TrimSpace(finding.Ref)
+	}
+
+	return Finding{
+		ID:             id,
+		RuleID:         ruleID,
+		ContractID:     findingContractID(finding, ruleID),
+		ContractSource: findingContractSource(finding),
+		Severity:       normalizeSeverity(finding.Severity),
+		Message:        strings.TrimSpace(finding.Message),
+		ComponentRef:   componentRef,
+		Net:            strings.TrimSpace(finding.Net),
+		Pin:            strings.TrimSpace(finding.Pin),
+		Requirement:    findingRequirement(finding, ruleID),
+		Fix:            strings.TrimSpace(finding.Fix),
+		Provenance:     findingProvenance(finding),
+	}
+}
+
+func (b *builder) graphFindings() []Finding {
+	out := make([]Finding, 0, len(b.findings))
+	for _, record := range b.findings {
+		out = append(out, record.finding)
+	}
+	return out
+}
+
+func summarizeFindings(findings []Finding) Summary {
+	summary := Summary{Findings: len(findings)}
+	for _, finding := range findings {
+		switch normalizeSeverity(finding.Severity) {
+		case "ERROR":
+			summary.Violations++
+		case "WARN":
+			summary.Warnings++
+		case "INFO":
+			summary.Infos++
+		}
+	}
+	return summary
+}
+
+func (b *builder) indexDesign() {
+	for _, part := range b.design.Parts {
+		ref := strings.TrimSpace(part.Ref)
+		if ref == "" {
+			continue
+		}
+		part.Ref = ref
+		b.partByRef[ref] = part
+	}
+	for _, net := range b.design.Nets {
+		netName := strings.TrimSpace(net.Name)
+		if netName == "" {
+			continue
+		}
+		net.Name = netName
+		pins := append([]ir.PinRef(nil), net.Pins...)
+		sort.Slice(pins, func(i, j int) bool {
+			if pins[i].Ref != pins[j].Ref {
+				return pins[i].Ref < pins[j].Ref
+			}
+			if pins[i].Pin != pins[j].Pin {
+				return pins[i].Pin < pins[j].Pin
+			}
+			return pins[i].Name < pins[j].Name
+		})
+		net.Pins = pins
+		b.netByName[netName] = net
+		for _, pin := range pins {
+			ref := strings.TrimSpace(pin.Ref)
+			if ref == "" {
+				continue
+			}
+			if _, ok := b.partByRef[ref]; !ok {
+				b.partByRef[ref] = ir.Part{Ref: ref}
+			}
+			b.netsByRef[ref] = appendUnique(b.netsByRef[ref], netName)
+			b.pinsByRef[ref] = append(b.pinsByRef[ref], ir.PinRef{Ref: ref, Pin: strings.TrimSpace(pin.Pin), Name: strings.TrimSpace(pin.Name)})
+		}
+	}
+	for ref := range b.netsByRef {
+		sort.Strings(b.netsByRef[ref])
+	}
+	for ref := range b.pinsByRef {
+		sort.Slice(b.pinsByRef[ref], func(i, j int) bool {
+			if b.pinsByRef[ref][i].Pin != b.pinsByRef[ref][j].Pin {
+				return b.pinsByRef[ref][i].Pin < b.pinsByRef[ref][j].Pin
+			}
+			return b.pinsByRef[ref][i].Name < b.pinsByRef[ref][j].Name
+		})
+	}
+}
+
+func (b *builder) indexVoltages() {
+	set := func(net string, voltage float64, source string, overwrite bool) {
+		net = strings.TrimSpace(net)
+		if net == "" {
+			return
+		}
+		if _, exists := b.voltageByNet[net]; exists && !overwrite {
+			return
+		}
+		b.voltageByNet[net] = voltage
+		b.voltageSource[net] = strings.TrimSpace(source)
+	}
+	if b.input.Report.Derived != nil {
+		for _, inferred := range b.input.Report.Derived.InferredNetVoltages {
+			set(inferred.Net, inferred.Voltage, inferred.Source, false)
+		}
+		for _, inference := range b.input.Report.Derived.RailInferences {
+			if inference.Voltage == nil {
+				continue
+			}
+			set(inference.NetName, *inference.Voltage, inference.Source, false)
+		}
+		for _, netVoltage := range b.input.Report.Derived.NetVoltages {
+			set(netVoltage.Net, netVoltage.Voltage, netVoltage.Source, true)
+		}
+	}
+	for _, net := range b.design.Nets {
+		if infer.IsGroundNetName(net.Name) {
+			set(net.Name, 0, "ground", false)
+		}
+	}
+}
+
+func (b *builder) buildNodes() []Node {
+	refs := make([]string, 0, len(b.partByRef))
+	for ref := range b.partByRef {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	nodes := make([]Node, 0, len(refs))
+	for _, ref := range refs {
+		part := b.partByRef[ref]
+		node := Node{
+			ID:               ref,
+			Ref:              ref,
+			Label:            nodeLabel(part),
+			Type:             classifyNode(part, b.input.ContractIR),
+			ContractCoverage: componentCoverage(ref, b.pinsByRef[ref], b.input.ContractIR),
+			FindingIDs:       []string{},
+			Nets:             append([]string{}, b.netsByRef[ref]...),
+			Metadata: NodeMetadata{
+				Value:        strings.TrimSpace(part.Value),
+				Footprint:    strings.TrimSpace(part.Footprint),
+				MPN:          firstNonEmpty(part.MPN, fieldValue(part.Fields, "mpn", "manufacturerpartnumber", "partnumber", "mfrpartnumber", "mfrpn", "pn")),
+				Manufacturer: firstNonEmpty(part.Manufacturer, fieldValue(part.Fields, "manufacturer", "mfr", "vendor")),
+			},
+		}
+		b.nodeIndex[node.ID] = len(nodes)
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+func (b *builder) buildEdges() []Edge {
+	netNames := make([]string, 0, len(b.netByName))
+	for netName := range b.netByName {
+		netNames = append(netNames, netName)
+	}
+	sort.Strings(netNames)
+	usedIDs := map[string]int{}
+	edges := make([]Edge, 0)
+	for _, netName := range netNames {
+		net := b.netByName[netName]
+		refs := uniqueRefsForNet(net)
+		if len(refs) < 2 {
+			continue
+		}
+		class := b.classifyNet(net)
+		voltage := b.edgeVoltage(net.Name)
+		for i := 0; i < len(refs); i++ {
+			for j := i + 1; j < len(refs); j++ {
+				source := refs[i]
+				target := refs[j]
+				id := uniqueGraphID("edge_"+sanitizeIDPart(source)+"_"+sanitizeIDPart(target)+"_"+sanitizeIDPart(net.Name), usedIDs)
+				edge := Edge{
+					ID:         id,
+					Source:     source,
+					Target:     target,
+					Net:        net.Name,
+					Type:       class.Type,
+					Domain:     class.Domain,
+					Interface:  class.Interface,
+					VoltageV:   voltage,
+					FindingIDs: []string{},
+				}
+				edges = append(edges, edge)
+			}
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].ID < edges[j].ID })
+	for i, edge := range edges {
+		b.edgeIndex[edge.ID] = i
+	}
+	return edges
+}
+
+func (b *builder) buildRails() []Rail {
+	netNames := make([]string, 0, len(b.voltageByNet))
+	for netName := range b.voltageByNet {
+		if _, ok := b.netByName[netName]; !ok {
+			continue
+		}
+		if !b.isRailNet(netName) {
+			continue
+		}
+		netNames = append(netNames, netName)
+	}
+	sort.Strings(netNames)
+	rails := make([]Rail, 0, len(netNames))
+	for _, netName := range netNames {
+		net := b.netByName[netName]
+		voltage := b.voltageByNet[netName]
+		sourceRef := b.sourceRefForRail(net)
+		consumers := uniqueRefsForNet(net)
+		if sourceRef != "" {
+			consumers = removeString(consumers, sourceRef)
+		}
+		rail := Rail{
+			Name:       netName,
+			VoltageV:   &voltage,
+			SourceRef:  sourceRef,
+			Consumers:  consumers,
+			FindingIDs: []string{},
+		}
+		b.railIndex[rail.Name] = len(rails)
+		rails = append(rails, rail)
+	}
+	return rails
+}
+
+func (b *builder) buildInterfaces() []Interface {
+	type ifaceBuilder struct {
+		id           string
+		kind         string
+		nets         map[string]struct{}
+		participants map[string]struct{}
+		pullups      map[string]InterfacePullup
+	}
+	byID := map[string]*ifaceBuilder{}
+	get := func(id string, kind string) *ifaceBuilder {
+		id = strings.TrimSpace(id)
+		if id == "" || id == "unknown" {
+			return nil
+		}
+		if kind != "i2c" && kind != "spi" && kind != "uart" {
+			return nil
+		}
+		if byID[id] == nil {
+			byID[id] = &ifaceBuilder{
+				id:           id,
+				kind:         kind,
+				nets:         map[string]struct{}{},
+				participants: map[string]struct{}{},
+				pullups:      map[string]InterfacePullup{},
+			}
+		}
+		return byID[id]
+	}
+	for _, edge := range b.edges {
+		builder := get(edge.Interface, edge.Type)
+		if builder == nil {
+			continue
+		}
+		builder.nets[edge.Net] = struct{}{}
+		builder.participants[edge.Source] = struct{}{}
+		builder.participants[edge.Target] = struct{}{}
+	}
+	for _, builder := range byID {
+		for _, pullup := range b.pullupsForInterface(builder.nets) {
+			builder.pullups[pullup.Ref+"\x00"+pullup.Net+"\x00"+pullup.ToNet] = pullup
+			delete(builder.participants, pullup.Ref)
+		}
+	}
+
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]Interface, 0, len(ids))
+	for _, id := range ids {
+		builder := byID[id]
+		pullups := make([]InterfacePullup, 0, len(builder.pullups))
+		for _, pullup := range builder.pullups {
+			pullups = append(pullups, pullup)
+		}
+		sort.Slice(pullups, func(i, j int) bool {
+			if pullups[i].Ref != pullups[j].Ref {
+				return pullups[i].Ref < pullups[j].Ref
+			}
+			if pullups[i].Net != pullups[j].Net {
+				return pullups[i].Net < pullups[j].Net
+			}
+			return pullups[i].ToNet < pullups[j].ToNet
+		})
+		iface := Interface{
+			ID:           id,
+			Type:         builder.kind,
+			Nets:         sortedSet(builder.nets),
+			Participants: sortedSet(builder.participants),
+			Pullups:      pullups,
+			FindingIDs:   []string{},
+		}
+		b.interfaceIndex[iface.ID] = len(out)
+		out = append(out, iface)
+	}
+	return out
+}
+
+func (b *builder) pullupsForInterface(nets map[string]struct{}) []InterfacePullup {
+	out := []InterfacePullup{}
+	for ref := range b.pinsByRef {
+		part := b.partByRef[ref]
+		if classifyNode(part, b.input.ContractIR) != "passive" || !strings.HasPrefix(strings.ToUpper(ref), "R") {
+			continue
+		}
+		resistance, ok := parseResistanceOhms(firstNonEmpty(part.Value, fieldValue(part.Fields, "resistance_ohms", "resistor_ohms", "ohms", "pullup_ohms")))
+		if !ok || resistance <= 0 {
+			continue
+		}
+		connectedNets := b.netsByRef[ref]
+		for _, signal := range connectedNets {
+			if _, ok := nets[signal]; !ok {
+				continue
+			}
+			for _, toNet := range connectedNets {
+				if toNet == signal || infer.IsGroundNetName(toNet) || !b.isRailNet(toNet) {
+					continue
+				}
+				out = append(out, InterfacePullup{
+					Ref:            ref,
+					Net:            signal,
+					ResistanceOhms: resistance,
+					ToNet:          toNet,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Ref != out[j].Ref {
+			return out[i].Ref < out[j].Ref
+		}
+		if out[i].Net != out[j].Net {
+			return out[i].Net < out[j].Net
+		}
+		return out[i].ToNet < out[j].ToNet
+	})
+	return out
+}
+
+func (b *builder) classifyNet(net ir.Net) netClass {
+	if iface, ok := b.interfaceByNet[net.Name]; ok && strings.HasPrefix(iface, "I2C") {
+		return netClass{Type: "i2c", Domain: "data", Interface: iface}
+	}
+	if b.netHasRole(net, contracts.RoleI2CSDA, contracts.RoleI2CSCL) || netHasAnyToken(net, "I2C", "SDA", "SCL") {
+		return netClass{Type: "i2c", Domain: "data", Interface: interfaceOrDefault(b.interfaceByNet[net.Name], "I2C_1")}
+	}
+	if b.netHasRole(net, contracts.RoleSPI) || netHasAnyToken(net, "SPI", "MISO", "MOSI", "SCK", "SCLK", "NSS", "CS", "CSN") {
+		return netClass{Type: "spi", Domain: "data", Interface: interfaceOrDefault(b.interfaceByNet[net.Name], "SPI_1")}
+	}
+	if b.netHasRole(net, contracts.RoleUART) || netHasAnyToken(net, "UART", "USART", "TX", "RX", "RTS", "CTS") {
+		return netClass{Type: "uart", Domain: "data", Interface: interfaceOrDefault(b.interfaceByNet[net.Name], "UART_1")}
+	}
+	if b.isRailNet(net.Name) || b.netHasRole(net, contracts.RolePowerIn, contracts.RolePowerOut, contracts.RoleRegulatorOut, contracts.RoleSource, contracts.RoleGround) {
+		return netClass{Type: "power", Domain: "power", Interface: net.Name}
+	}
+	if b.netHasRole(net, contracts.RoleMotorOut) || netHasAnyToken(net, "MOTOR", "MOT", "OUTA", "OUTB", "AOUT", "BOUT") {
+		return netClass{Type: "motor", Domain: "control", Interface: "MOTOR"}
+	}
+	if netHasAnyToken(net, "ADC", "DAC", "AIN", "AOUT", "ANALOG") {
+		return netClass{Type: "analog", Domain: "data", Interface: "ANALOG"}
+	}
+	if b.netHasRole(net, contracts.RoleGPIO) || netHasAnyToken(net, "GPIO") {
+		return netClass{Type: "gpio", Domain: "control", Interface: "GPIO"}
+	}
+	return netClass{Type: "unknown", Domain: "unknown", Interface: "unknown"}
+}
+
+func (b *builder) edgeVoltage(net string) *float64 {
+	voltage, ok := b.voltageByNet[strings.TrimSpace(net)]
+	if !ok {
+		return nil
+	}
+	return &voltage
+}
+
+func (b *builder) isRailNet(netName string) bool {
+	netName = strings.TrimSpace(netName)
+	if netName == "" {
+		return false
+	}
+	if _, ok := b.voltageByNet[netName]; ok {
+		return true
+	}
+	if infer.IsGroundNetName(netName) {
+		return true
+	}
+	return looksLikePowerNetName(netName)
+}
+
+func (b *builder) netHasRole(net ir.Net, roles ...contracts.PinRole) bool {
+	if b.input.ContractIR == nil {
+		return false
+	}
+	wanted := map[contracts.PinRole]struct{}{}
+	for _, role := range roles {
+		wanted[role] = struct{}{}
+	}
+	for _, pin := range net.Pins {
+		contract, ok := b.input.ContractIR.Pin(pin.Ref, pin.Pin)
+		if !ok {
+			continue
+		}
+		if _, ok := wanted[contract.Role]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *builder) sourceRefForRail(net ir.Net) string {
+	if source := strings.TrimSpace(b.voltageSource[net.Name]); strings.HasPrefix(source, "regulator:") {
+		ref := strings.TrimSpace(strings.TrimPrefix(source, "regulator:"))
+		if ref != "" {
+			return ref
+		}
+	}
+	if b.input.ContractIR != nil {
+		for _, pin := range net.Pins {
+			contract, ok := b.input.ContractIR.Pin(pin.Ref, pin.Pin)
+			if !ok {
+				continue
+			}
+			switch contract.Role {
+			case contracts.RoleSource, contracts.RolePowerOut, contracts.RoleRegulatorOut:
+				return pin.Ref
+			}
+		}
+	}
+	refs := uniqueRefsForNet(net)
+	for _, ref := range refs {
+		if classifyNode(b.partByRef[ref], b.input.ContractIR) == "power_source" {
+			return ref
+		}
+	}
+	for _, ref := range refs {
+		if classifyNode(b.partByRef[ref], b.input.ContractIR) == "connector" {
+			return ref
+		}
+	}
+	if len(refs) > 0 && !infer.IsGroundNetName(net.Name) {
+		return refs[0]
+	}
+	return ""
+}
+
+func (b *builder) attachFindings() map[string]FindingLink {
+	index := map[string]FindingLink{}
+	for _, record := range b.findings {
+		finding := record.raw
+		findingID := record.id
+		nets := b.affectedNets(finding)
+		refs := b.affectedRefs(finding, nets)
+		interfaceIDs := b.affectedInterfaceIDs(finding, nets)
+		link := FindingLink{
+			NodeIDs:      sortedSet(refs),
+			EdgeIDs:      b.affectedEdgeIDs(nets, refs, interfaceIDs, finding),
+			RailNames:    b.affectedRailNames(nets),
+			InterfaceIDs: interfaceIDs,
+		}
+		index[findingID] = link
+		severity := normalizeSeverity(finding.Severity)
+		for _, nodeID := range link.NodeIDs {
+			if idx, ok := b.nodeIndex[nodeID]; ok {
+				incrementSeverity(severity, &b.nodes[idx].Violations, &b.nodes[idx].Warnings)
+				b.nodes[idx].FindingIDs = appendUnique(b.nodes[idx].FindingIDs, findingID)
+			}
+		}
+		for _, edgeID := range link.EdgeIDs {
+			if idx, ok := b.edgeIndex[edgeID]; ok {
+				incrementSeverity(severity, &b.edges[idx].Violations, &b.edges[idx].Warnings)
+				b.edges[idx].FindingIDs = appendUnique(b.edges[idx].FindingIDs, findingID)
+			}
+		}
+		for _, railName := range link.RailNames {
+			if idx, ok := b.railIndex[railName]; ok {
+				incrementSeverity(severity, &b.rails[idx].Violations, &b.rails[idx].Warnings)
+				b.rails[idx].FindingIDs = appendUnique(b.rails[idx].FindingIDs, findingID)
+			}
+		}
+		for _, interfaceID := range link.InterfaceIDs {
+			if idx, ok := b.interfaceIndex[interfaceID]; ok {
+				incrementSeverity(severity, &b.interfaces[idx].Violations, &b.interfaces[idx].Warnings)
+				b.interfaces[idx].FindingIDs = appendUnique(b.interfaces[idx].FindingIDs, findingID)
+			}
+		}
+	}
+	b.sortFindingIDs()
+	return index
+}
+
+func (b *builder) affectedNets(finding report.RuleResult) []string {
+	nets := []string{}
+	add := func(net string) {
+		net = strings.TrimSpace(net)
+		if net != "" {
+			nets = appendUnique(nets, net)
+		}
+	}
+	add(finding.Net)
+	if strings.TrimSpace(finding.Net) == "" && finding.BusNets != nil {
+		add(finding.BusNets.SDA)
+		add(finding.BusNets.SCL)
+	}
+	if finding.Inference != nil {
+		add(finding.Inference.NetName)
+	}
+	add(conflictNetName(finding.Message))
+	for netName := range b.netByName {
+		if containsExactText(finding.Message, netName) {
+			add(netName)
+		}
+	}
+	sort.Strings(nets)
+	return nets
+}
+
+func (b *builder) affectedRefs(finding report.RuleResult, nets []string) map[string]struct{} {
+	refs := map[string]struct{}{}
+	addRef := func(ref string) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			return
+		}
+		if _, ok := b.partByRef[ref]; ok {
+			refs[ref] = struct{}{}
+		}
+	}
+	addRef(finding.Ref)
+	addRef(finding.ComponentRef)
+	for _, ref := range finding.PullupResistors {
+		addRef(ref)
+	}
+	for _, text := range []string{finding.Provider, finding.Consumer, finding.Message} {
+		for _, ref := range refsMentioned(text, b.partByRef) {
+			addRef(ref)
+		}
+	}
+	return refs
+}
+
+func (b *builder) affectedEdgeIDs(nets []string, refs map[string]struct{}, interfaceIDs []string, finding report.RuleResult) []string {
+	netSet := exactStringSet(nets)
+	interfaceSet := exactStringSet(interfaceIDs)
+	includeInterfaceEdges := isBusLevelFinding(finding, nets)
+	out := []string{}
+	for _, edge := range b.edges {
+		_, netMatch := netSet[edge.Net]
+		_, interfaceMatch := interfaceSet[edge.Interface]
+		if !netMatch && !(includeInterfaceEdges && interfaceMatch) {
+			continue
+		}
+		if netMatch && len(refs) > 0 {
+			_, source := refs[edge.Source]
+			_, target := refs[edge.Target]
+			if !source && !target {
+				continue
+			}
+		}
+		out = append(out, edge.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (b *builder) affectedInterfaceIDs(finding report.RuleResult, nets []string) []string {
+	out := []string{}
+	if finding.BusNets != nil {
+		for _, net := range []string{finding.BusNets.SDA, finding.BusNets.SCL} {
+			if iface := strings.TrimSpace(b.interfaceByNet[net]); iface != "" {
+				out = appendUnique(out, iface)
+			}
+		}
+	}
+	for _, net := range nets {
+		if iface := strings.TrimSpace(b.interfaceByNet[net]); iface != "" {
+			out = appendUnique(out, iface)
+		}
+	}
+	if strings.EqualFold(finding.BusType, "i2c") && strings.TrimSpace(finding.BusID) != "" {
+		iface := normalizeInterfaceID("I2C", finding.BusID)
+		if _, ok := b.interfaceIndex[iface]; ok {
+			out = appendUnique(out, iface)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func isBusLevelFinding(finding report.RuleResult, nets []string) bool {
+	if !strings.EqualFold(finding.BusType, "i2c") && finding.BusNets == nil {
+		return false
+	}
+	return strings.TrimSpace(finding.Net) == "" && len(nets) > 0
+}
+
+func (b *builder) affectedRailNames(nets []string) []string {
+	out := []string{}
+	for _, net := range nets {
+		if _, ok := b.railIndex[net]; ok {
+			out = appendUnique(out, net)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (b *builder) sortFindingIDs() {
+	for i := range b.nodes {
+		sort.Strings(b.nodes[i].FindingIDs)
+	}
+	for i := range b.edges {
+		sort.Strings(b.edges[i].FindingIDs)
+	}
+	for i := range b.rails {
+		sort.Strings(b.rails[i].FindingIDs)
+	}
+	for i := range b.interfaces {
+		sort.Strings(b.interfaces[i].FindingIDs)
+	}
+}
+
+func buildInterfaceIndex(design *ir.DesignIR, contractIR *contracts.ContractIR, result report.VerificationReport) map[string]string {
+	out := map[string]string{}
+	addI2C := func(busID string, nets *contracts.I2CBusNets) {
+		if nets == nil {
+			return
+		}
+		iface := normalizeInterfaceID("I2C", busID)
+		if strings.TrimSpace(nets.SDA) != "" {
+			out[strings.TrimSpace(nets.SDA)] = iface
+		}
+		if strings.TrimSpace(nets.SCL) != "" {
+			out[strings.TrimSpace(nets.SCL)] = iface
+		}
+	}
+	for _, finding := range result.Findings {
+		if strings.EqualFold(finding.BusType, "i2c") || finding.BusNets != nil {
+			addI2C(finding.BusID, finding.BusNets)
+		}
+	}
+	if contractIR != nil {
+		for _, req := range contractIR.AppliedRequirements {
+			if strings.EqualFold(req.Scope.BusType, "i2c") || req.Scope.Nets != nil {
+				addI2C(req.Scope.BusID, req.Scope.Nets)
+			}
+		}
+	}
+
+	i2cGroups := []netGroup{}
+	spiGroups := []netGroup{}
+	uartGroups := []netGroup{}
+	if design != nil {
+		for _, net := range design.Nets {
+			if _, ok := out[net.Name]; ok {
+				continue
+			}
+			if key, ok := busKeyFromNetName(net.Name, "I2C", []string{"SDA", "SCL"}); ok {
+				i2cGroups = append(i2cGroups, netGroup{net: net.Name, key: key})
+			}
+			if key, ok := busKeyFromNetName(net.Name, "SPI", []string{"MISO", "MOSI", "SCK", "SCLK", "NSS", "CS", "CSN"}); ok {
+				spiGroups = append(spiGroups, netGroup{net: net.Name, key: key})
+			}
+			if key, ok := busKeyFromNetName(net.Name, "UART", []string{"TX", "RX", "RTS", "CTS"}); ok {
+				uartGroups = append(uartGroups, netGroup{net: net.Name, key: key})
+			}
+		}
+	}
+	assignInferredInterfaces(out, "I2C", i2cGroups)
+	assignInferredInterfaces(out, "SPI", spiGroups)
+	assignInferredInterfaces(out, "UART", uartGroups)
+	return out
+}
+
+func assignInferredInterfaces(out map[string]string, prefix string, groups []netGroup) {
+	if len(groups) == 0 {
+		return
+	}
+	groups = append([]netGroup(nil), groups...)
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].key != groups[j].key {
+			return groups[i].key < groups[j].key
+		}
+		return groups[i].net < groups[j].net
+	})
+	keys := []string{}
+	for _, group := range groups {
+		keys = appendUnique(keys, group.key)
+	}
+	sort.Strings(keys)
+	interfaces := map[string]string{}
+	for i, key := range keys {
+		interfaces[key] = fmt.Sprintf("%s_%d", strings.ToUpper(prefix), i+1)
+	}
+	for _, group := range groups {
+		if _, exists := out[group.net]; exists {
+			continue
+		}
+		out[group.net] = interfaces[group.key]
+	}
+}
+
+func nodeLabel(part ir.Part) string {
+	ref := strings.TrimSpace(part.Ref)
+	value := strings.TrimSpace(part.Value)
+	if value == "" {
+		return ref
+	}
+	return ref + " " + value
+}
+
+func classifyNode(part ir.Part, contractIR *contracts.ContractIR) string {
+	ref := strings.ToUpper(strings.TrimSpace(part.Ref))
+	text := strings.ToUpper(strings.Join([]string{
+		part.Ref,
+		part.Value,
+		part.Footprint,
+		part.MPN,
+		part.Manufacturer,
+		fieldValue(part.Fields, "description", "datasheet", "device", "part", "component"),
+	}, " "))
+	normalized := compactAlphaNum(text)
+
+	if hasAny(normalized, "TB6612", "L298", "L293", "A4988", "DRV8", "TMC", "MOTORDRIVER", "MOTORCONTROLLER") || strings.Contains(text, "MOTOR DRIVER") {
+		return "motor_driver"
+	}
+	if hasAny(normalized, "ESP32", "ESP8266", "RP2040", "STM32", "ATMEGA", "ATTINY", "ARDUINO", "WROOM", "WROVER", "MICROCONTROLLER") || tokenInText(text, "MCU") {
+		return "mcu"
+	}
+	if hasAny(normalized, "BME", "BMP", "MPU", "VL53", "VL6180", "LSM", "LIS", "SHT", "DHT", "IMU") || tokenInText(text, "SENSOR") {
+		return "sensor"
+	}
+	if hasAny(normalized, "AMS1117", "LM1117", "AP2112", "MP1584", "LM2596") || tokenInText(text, "REGULATOR") || tokenInText(text, "LDO") || tokenInText(text, "BUCK") || tokenInText(text, "BOOST") {
+		return "regulator"
+	}
+	if strings.HasPrefix(ref, "J") || strings.HasPrefix(ref, "P") || strings.HasPrefix(ref, "CN") || tokenInText(text, "CONNECTOR") || tokenInText(text, "HEADER") || strings.Contains(text, "CONN_") || tokenInText(text, "USB") {
+		return "connector"
+	}
+	if strings.HasPrefix(ref, "BT") || strings.HasPrefix(ref, "BAT") || tokenInText(text, "BATTERY") || tokenInText(text, "POWER_SOURCE") {
+		return "power_source"
+	}
+	if len(ref) > 0 {
+		switch ref[0] {
+		case 'R', 'C', 'L', 'D', 'F', 'Y':
+			return "passive"
+		}
+	}
+	if contractIR != nil {
+		if component, ok := contractIR.Components[part.Ref]; ok {
+			for _, pin := range component.Pins {
+				switch pin.Role {
+				case contracts.RoleRegulatorOut:
+					return "regulator"
+				case contracts.RoleMotorOut:
+					return "motor_driver"
+				case contracts.RoleSource:
+					return "power_source"
+				}
+			}
+		}
+	}
+	return "unknown"
+}
+
+func componentCoverage(ref string, pins []ir.PinRef, contractIR *contracts.ContractIR) string {
+	if contractIR == nil {
+		return "unknown"
+	}
+	component, hasComponent := contractIR.Components[strings.TrimSpace(ref)]
+	componentCovered := hasComponent && (component.MPN != "" || component.Source != "" || component.VoltageMax != nil || len(component.Pins) > 0)
+	seenPins := map[string]struct{}{}
+	for _, pin := range pins {
+		if strings.TrimSpace(pin.Pin) != "" {
+			seenPins[pin.Pin] = struct{}{}
+		}
+	}
+	if len(seenPins) == 0 {
+		if componentCovered {
+			return "partial"
+		}
+		return "missing"
+	}
+	coveredPins := 0
+	for pin := range seenPins {
+		if _, ok := contractIR.Pin(ref, pin); ok {
+			coveredPins++
+		}
+	}
+	switch {
+	case componentCovered && coveredPins == len(seenPins):
+		return "full"
+	case componentCovered || coveredPins > 0:
+		return "partial"
+	default:
+		return "missing"
+	}
+}
+
+func normalizeInterfaceID(prefix string, id string) string {
+	prefix = strings.ToUpper(strings.TrimSpace(prefix))
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return prefix + "_1"
+	}
+	normalized := strings.ToUpper(sanitizeIDPart(id))
+	if strings.HasPrefix(normalized, prefix+"_") || normalized == prefix {
+		return normalized
+	}
+	return prefix + "_" + normalized
+}
+
+func busKeyFromNetName(netName string, busPrefix string, signalTokens []string) (string, bool) {
+	tokens := netTokens(netName)
+	if len(tokens) == 0 {
+		return "", false
+	}
+	signalSet := stringSet(signalTokens)
+	hasSignal := false
+	keyTokens := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if _, ok := signalSet[token]; ok {
+			hasSignal = true
+			continue
+		}
+		keyTokens = append(keyTokens, token)
+	}
+	if !hasSignal {
+		return "", false
+	}
+	hasPrefix := false
+	for _, token := range keyTokens {
+		if token == busPrefix {
+			hasPrefix = true
+			break
+		}
+	}
+	if !hasPrefix && busPrefix != "UART" {
+		return "", false
+	}
+	if len(keyTokens) == 0 {
+		return busPrefix, true
+	}
+	return strings.Join(keyTokens, "_"), true
+}
+
+func netHasAnyToken(net ir.Net, tokens ...string) bool {
+	wanted := stringSet(tokens)
+	for _, token := range netTokens(net.Name) {
+		if _, ok := wanted[token]; ok {
+			return true
+		}
+	}
+	for _, pin := range net.Pins {
+		for _, token := range netTokens(pin.Name) {
+			if _, ok := wanted[token]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func looksLikePowerNetName(netName string) bool {
+	if infer.IsGroundNetName(netName) {
+		return true
+	}
+	tokens := netTokens(netName)
+	for _, token := range tokens {
+		if _, ok := map[string]struct{}{
+			"VCC": {}, "VDD": {}, "VSS": {}, "VIN": {}, "VBAT": {}, "VBUS": {}, "VSYS": {}, "VREF": {},
+			"+5V": {}, "+3V3": {}, "5V": {}, "3V3": {}, "12V": {}, "24V": {}, "POWER": {}, "PWR": {},
+		}[token]; ok {
+			return true
+		}
+		if voltageTokenPattern.MatchString(token) {
+			return true
+		}
+	}
+	return false
+}
+
+var voltageTokenPattern = regexp.MustCompile(`^\+?[0-9]+(?:V[0-9]+|(?:\.[0-9]+)?V)$`)
+
+func netTokens(value string) []string {
+	fields := strings.FieldsFunc(strings.ToUpper(strings.TrimSpace(value)), func(r rune) bool {
+		return !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '+')
+	})
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+func findingContractID(finding report.RuleResult, fallback string) string {
+	if id := strings.TrimSpace(finding.ContractID); id != "" {
+		return id
+	}
+	if finding.Provenance != nil {
+		if id := strings.TrimSpace(finding.Provenance.SourceID); id != "" {
+			return id
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func findingContractSource(finding report.RuleResult) string {
+	source := strings.TrimSpace(finding.ContractSource)
+	switch source {
+	case string(contracts.ContractSourceBuiltIn),
+		string(contracts.ContractSourceUserYAML),
+		string(contracts.ContractSourceMetaYAML),
+		string(contracts.ContractSourceInferred):
+		return source
+	}
+	return string(contracts.ReportContractSource(finding.Source))
+}
+
+func findingRequirement(finding report.RuleResult, fallback string) string {
+	if requirement := strings.TrimSpace(finding.Requirement); requirement != "" {
+		return requirement
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func findingProvenance(finding report.RuleResult) string {
+	if finding.Provenance == nil {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if source := strings.TrimSpace(finding.Provenance.Source); source != "" {
+		parts = append(parts, "source="+source)
+	}
+	if sourceID := strings.TrimSpace(finding.Provenance.SourceID); sourceID != "" {
+		parts = append(parts, "source_id="+sourceID)
+	}
+	if detail := strings.TrimSpace(finding.Provenance.Detail); detail != "" {
+		parts = append(parts, "detail="+detail)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func normalizeSeverity(severity string) string {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "WARN", "WARNING":
+		return "WARN"
+	case "INFO":
+		return "INFO"
+	default:
+		return "ERROR"
+	}
+}
+
+func incrementSeverity(severity string, violations *int, warnings *int) {
+	switch severity {
+	case "WARN":
+		(*warnings)++
+	case "ERROR":
+		(*violations)++
+	}
+}
+
+func refsMentioned(text string, parts map[string]ir.Part) []string {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	out := []string{}
+	for ref := range parts {
+		if containsRefToken(text, ref) {
+			out = append(out, ref)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsRefToken(text string, ref string) bool {
+	return containsExactText(text, ref)
+}
+
+func containsExactText(text string, value string) bool {
+	upperText := strings.ToUpper(text)
+	upperRef := strings.ToUpper(value)
+	if upperRef == "" || len(upperText) < len(upperRef) {
+		return false
+	}
+	start := 0
+	for {
+		idx := strings.Index(upperText[start:], upperRef)
+		if idx < 0 {
+			return false
+		}
+		idx += start
+		beforeOK := idx == 0 || !isRefByte(upperText[idx-1])
+		afterIndex := idx + len(upperRef)
+		afterOK := afterIndex >= len(upperText) || !isRefByte(upperText[afterIndex])
+		if beforeOK && afterOK {
+			return true
+		}
+		start = idx + len(upperRef)
+		if start >= len(upperText) {
+			return false
+		}
+	}
+}
+
+func isRefByte(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '-'
+}
+
+func conflictNetName(message string) string {
+	const prefix = "Voltage conflict on net "
+	if !strings.HasPrefix(message, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(message, prefix)
+	if idx := strings.Index(rest, ":"); idx >= 0 {
+		rest = rest[:idx]
+	}
+	return strings.TrimSpace(rest)
+}
+
+func uniqueRefsForNet(net ir.Net) []string {
+	seen := map[string]struct{}{}
+	refs := []string{}
+	for _, pin := range net.Pins {
+		ref := strings.TrimSpace(pin.Ref)
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+func appendUnique(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func removeString(values []string, remove string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != remove {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.ToUpper(strings.TrimSpace(value))
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func exactStringSet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func interfaceOrDefault(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func sanitizeIDPart(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "unknown"
+	}
+	return out
+}
+
+func uniqueGraphID(base string, used map[string]int) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "id"
+	}
+	used[base]++
+	if used[base] == 1 {
+		return base
+	}
+	return fmt.Sprintf("%s_%d", base, used[base])
+}
+
+func fieldValue(fields map[string]string, keys ...string) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	wanted := map[string]struct{}{}
+	for _, key := range keys {
+		wanted[compactAlphaNum(key)] = struct{}{}
+	}
+	matches := make([]string, 0, len(fields))
+	for key, value := range fields {
+		if _, ok := wanted[compactAlphaNum(key)]; ok && strings.TrimSpace(value) != "" {
+			matches = append(matches, strings.TrimSpace(value))
+		}
+	}
+	sort.Strings(matches)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+func parseResistanceOhms(value string) (float64, bool) {
+	value = strings.TrimSpace(strings.ToLower(value))
+	value = strings.Trim(value, `"'`)
+	if value == "" {
+		return 0, false
+	}
+	value = strings.ReplaceAll(value, "ohms", "")
+	value = strings.ReplaceAll(value, "ohm", "")
+	value = strings.ReplaceAll(value, "Ω", "")
+	value = strings.TrimSpace(value)
+	multiplier := 1.0
+	switch {
+	case strings.HasSuffix(value, "kohm"):
+		multiplier = 1000
+		value = strings.TrimSuffix(value, "kohm")
+	case strings.HasSuffix(value, "k"):
+		multiplier = 1000
+		value = strings.TrimSuffix(value, "k")
+	case strings.HasSuffix(value, "m"):
+		multiplier = 1000000
+		value = strings.TrimSuffix(value, "m")
+	}
+	if strings.Contains(value, "k") {
+		value = strings.Replace(value, "k", ".", 1)
+		multiplier = 1000
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed * multiplier, true
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func compactAlphaNum(value string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(strings.TrimSpace(value)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func hasAny(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, compactAlphaNum(needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenInText(text string, token string) bool {
+	token = strings.ToUpper(strings.TrimSpace(token))
+	if token == "" {
+		return false
+	}
+	for _, got := range netTokens(text) {
+		if got == token {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -1,0 +1,126 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/badimirzai/architon-cli/internal/ir"
+	"github.com/badimirzai/architon-cli/internal/report"
+)
+
+func TestBuild_DistinguishesEdgeTypesDomainsAndInterfaces(t *testing.T) {
+	design := &ir.DesignIR{
+		Version: ir.SchemaVersion,
+		Parts: []ir.Part{
+			{Ref: "U1", Value: "Controller"},
+			{Ref: "U2", Value: "Peripheral"},
+		},
+		Nets: []ir.Net{
+			twoPinNet("I2C_SDA"),
+			twoPinNet("SPI_MOSI"),
+			twoPinNet("UART_TX"),
+			twoPinNet("GPIO_4"),
+			twoPinNet("+3V3"),
+			twoPinNet("NET_UNCLASSIFIED"),
+		},
+	}
+
+	graph := Build(BuildInput{
+		RVVersion: "test",
+		InputPath: "fixture.net",
+		Design:    design,
+	})
+
+	tests := []struct {
+		net        string
+		wantType   string
+		wantDomain string
+		wantIface  string
+	}{
+		{net: "I2C_SDA", wantType: "i2c", wantDomain: "data", wantIface: "I2C_1"},
+		{net: "SPI_MOSI", wantType: "spi", wantDomain: "data", wantIface: "SPI_1"},
+		{net: "UART_TX", wantType: "uart", wantDomain: "data", wantIface: "UART_1"},
+		{net: "GPIO_4", wantType: "gpio", wantDomain: "control", wantIface: "GPIO"},
+		{net: "+3V3", wantType: "power", wantDomain: "power", wantIface: "+3V3"},
+		{net: "NET_UNCLASSIFIED", wantType: "unknown", wantDomain: "unknown", wantIface: "unknown"},
+	}
+
+	for _, tt := range tests {
+		edge := requireEdgeForNet(t, graph, tt.net)
+		if edge.Type != tt.wantType || edge.Domain != tt.wantDomain || edge.Interface != tt.wantIface {
+			t.Fatalf("edge %s classified as type=%q domain=%q interface=%q, want type=%q domain=%q interface=%q",
+				tt.net, edge.Type, edge.Domain, edge.Interface, tt.wantType, tt.wantDomain, tt.wantIface)
+		}
+	}
+}
+
+func TestBuild_RollsWarningsOntoAffectedGraphElements(t *testing.T) {
+	design := &ir.DesignIR{
+		Version: ir.SchemaVersion,
+		Parts: []ir.Part{
+			{Ref: "U1", Value: "Controller"},
+			{Ref: "U2", Value: "Peripheral"},
+		},
+		Nets: []ir.Net{twoPinNet("GPIO_4")},
+	}
+
+	graph := Build(BuildInput{
+		RVVersion: "test",
+		InputPath: "fixture.net",
+		Design:    design,
+		Report: report.VerificationReport{
+			Findings: []report.RuleResult{
+				{ID: "RULE_WARN", RuleID: "RULE_WARN", Severity: "WARN", Net: "GPIO_4", ComponentRef: "U1", Message: "test warning"},
+			},
+		},
+	})
+
+	edge := requireEdgeForNet(t, graph, "GPIO_4")
+	if edge.Warnings != 1 || edge.Violations != 0 {
+		t.Fatalf("expected warning rollup on GPIO edge, got %+v", edge)
+	}
+	if len(edge.FindingIDs) != 1 || edge.FindingIDs[0] != "RULE_WARN" {
+		t.Fatalf("expected edge finding_ids to include RULE_WARN, got %+v", edge.FindingIDs)
+	}
+	link := graph.FindingsIndex["RULE_WARN"]
+	if len(link.EdgeIDs) != 1 || link.EdgeIDs[0] != edge.ID {
+		t.Fatalf("expected finding index to link edge %s, got %+v", edge.ID, link)
+	}
+	if node := requireNodeForID(t, graph, "U1"); node.Warnings != 1 || node.Violations != 0 {
+		t.Fatalf("expected warning rollup on U1, got %+v", node)
+	}
+	if node := requireNodeForID(t, graph, "U2"); node.Warnings != 0 || node.Violations != 0 {
+		t.Fatalf("expected warning not to roll up to unrelated U2, got %+v", node)
+	}
+}
+
+func twoPinNet(name string) ir.Net {
+	return ir.Net{
+		Name: name,
+		Pins: []ir.PinRef{
+			{Ref: "U1", Pin: name + "_A", Name: name},
+			{Ref: "U2", Pin: name + "_B", Name: name},
+		},
+	}
+}
+
+func requireEdgeForNet(t *testing.T, graph GraphIR, net string) Edge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Net == net {
+			return edge
+		}
+	}
+	t.Fatalf("missing edge for net %q in %+v", net, graph.Edges)
+	return Edge{}
+}
+
+func requireNodeForID(t *testing.T, graph GraphIR, id string) Node {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.ID == id {
+			return node
+		}
+	}
+	t.Fatalf("missing node %q in %+v", id, graph.Nodes)
+	return Node{}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/badimirzai/architon-cli/internal/contracts"
 	"github.com/badimirzai/architon-cli/internal/infer"
@@ -174,8 +175,73 @@ func CanonicalizeVerificationReport(result VerificationReport) VerificationRepor
 	if len(result.Findings) == 0 && len(result.Rules) > 0 {
 		result.Findings = append([]RuleResult{}, result.Rules...)
 	}
+	findings := append([]RuleResult{}, result.Findings...)
+	ids := canonicalFindingIDs(findings)
+	for i := range findings {
+		findings[i].ID = ids[i]
+		if strings.TrimSpace(findings[i].RuleID) == "" {
+			findings[i].RuleID = ids[i]
+		}
+	}
+	result.Findings = findings
 	result.Rules = append([]RuleResult{}, result.Findings...)
 	return result
+}
+
+func canonicalFindingIDs(findings []RuleResult) []string {
+	bases := make([]string, len(findings))
+	counts := map[string]int{}
+	for i, finding := range findings {
+		base := firstNonEmpty(finding.ID, finding.RuleID, "finding")
+		base = sanitizeIDPart(base)
+		bases[i] = base
+		counts[base]++
+	}
+	seen := map[string]int{}
+	out := make([]string, len(findings))
+	for i, base := range bases {
+		seen[base]++
+		if counts[base] == 1 {
+			out[i] = base
+			continue
+		}
+		out[i] = fmt.Sprintf("%s_%02d", base, seen[base])
+	}
+	return out
+}
+
+func sanitizeIDPart(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "unknown"
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func hasRuleFailures(rules []RuleResult) bool {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -148,3 +148,22 @@ func TestCanonicalizeVerificationReport_PopulatesRulesAliasFromFindings(t *testi
 		t.Fatalf("expected rules alias to equal findings, got rules=%+v findings=%+v", result.Rules, result.Findings)
 	}
 }
+
+func TestCanonicalizeVerificationReport_AssignsStableDuplicateFindingIDs(t *testing.T) {
+	result := CanonicalizeVerificationReport(VerificationReport{
+		Findings: []RuleResult{
+			{ID: "pullup_ohms", RuleID: "pullup_ohms", Severity: "ERROR", Message: "bad pullup A"},
+			{ID: "pullup_ohms", RuleID: "pullup_ohms", Severity: "ERROR", Message: "bad pullup B"},
+		},
+	})
+
+	if got, want := result.Findings[0].ID, "pullup_ohms_01"; got != want {
+		t.Fatalf("expected first duplicate finding ID %q, got %q", want, got)
+	}
+	if got, want := result.Findings[1].ID, "pullup_ohms_02"; got != want {
+		t.Fatalf("expected second duplicate finding ID %q, got %q", want, got)
+	}
+	if !reflect.DeepEqual(result.Rules, result.Findings) {
+		t.Fatalf("expected rules alias to equal canonical findings, got rules=%+v findings=%+v", result.Rules, result.Findings)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"strings"
+)
 
 // Info describes the current build version metadata.
 type Info struct {
@@ -11,19 +14,23 @@ type Info struct {
 
 // Get returns version info derived from Go build metadata when available.
 func Get() Info {
-	info := Info{Version: "v0.5.0-dev"}
+	info := Info{Version: "v0.6.0-dev"}
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok && buildInfo != nil {
-		if buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
-			info.Version = buildInfo.Main.Version
-		}
+		moduleVersion := strings.TrimSpace(buildInfo.Main.Version)
+		modified := false
 		for _, setting := range buildInfo.Settings {
 			switch setting.Key {
 			case "vcs.revision":
 				info.GitCommit = setting.Value
 			case "vcs.time":
 				info.BuildDate = setting.Value
+			case "vcs.modified":
+				modified = setting.Value == "true"
 			}
+		}
+		if moduleVersion != "" && moduleVersion != "(devel)" && !modified && !strings.Contains(moduleVersion, "+dirty") {
+			info.Version = moduleVersion
 		}
 	}
 	return info


### PR DESCRIPTION
Adds rv graph with machine-readable GraphIR for Studio and visual reporting. GraphIR now includes nodes, edges, rails, interfaces, embedded findings, and finding indexes. It reuses the same contract evaluation pipeline as rv scan, so custom system contract violations are reflected directly in graph nodes, edges, and interfaces.